### PR TITLE
fix: refactor log output formatting and address spinner display

### DIFF
--- a/src/lib/actions/BaseAction.ts
+++ b/src/lib/actions/BaseAction.ts
@@ -2,6 +2,7 @@ import {ConfigFileManager} from "../../lib/config/ConfigFileManager";
 import ora, {Ora} from "ora";
 import chalk from "chalk";
 import inquirer from "inquirer";
+import { inspect } from "util";
 import {KeypairManager} from "../accounts/KeypairManager";
 import {createClient, createAccount} from "genlayer-js";
 import {localnet} from "genlayer-js/chains";
@@ -58,20 +59,10 @@ export class BaseAction extends ConfigFileManager {
   }
 
   private formatOutput(data: any): string {
-    if (data instanceof Error) {
-      const errorDetails = {
-        name: data.name,
-        message: data.message,
-        ...(Object.keys(data).length ? data : {}),
-      };
-      return JSON.stringify(errorDetails, null, 2);
+    if (typeof data === "string") {
+      return data;
     }
-
-    if (data instanceof Map) {
-      data = Object.fromEntries(data);
-    }
-
-    return typeof data === "object" ? JSON.stringify(data, null, 2) : String(data);
+    return inspect(data, { depth: null, colors: false });
   }
 
   protected log(message: string, data?: any): void {
@@ -106,11 +97,13 @@ export class BaseAction extends ConfigFileManager {
 
   protected succeedSpinner(message: string, data?: any): void {
     if (data !== undefined) this.log("Result:", data);
+    console.log('');
     this.spinner.succeed(chalk.green(message));
   }
 
-  protected failSpinner(message: string, error?: any): void {
+  protected failSpinner(message: string, error?:any): void {
     if (error) this.log("Error:", error);
+    console.log('');
     this.spinner.fail(chalk.red(message));
   }
 

--- a/tests/libs/baseAction.test.ts
+++ b/tests/libs/baseAction.test.ts
@@ -3,6 +3,7 @@ import {BaseAction} from "../../src/lib/actions/BaseAction";
 import inquirer from "inquirer";
 import ora, {Ora} from "ora";
 import chalk from "chalk";
+import {inspect} from "util";
 
 vi.mock("inquirer");
 vi.mock("ora");
@@ -42,11 +43,17 @@ describe("BaseAction", () => {
 
   test("should succeed the spinner with a message", () => {
     baseAction["succeedSpinner"]("Success");
+    expect(consoleSpy).toHaveBeenCalledWith("");
     expect(mockSpinner.succeed).toHaveBeenCalledWith(expect.stringContaining("Success"));
   });
 
   test("should fail the spinner with an error message", () => {
-    baseAction["failSpinner"]("Failure", new Error("Something went wrong"));
+    const error = new Error("Something went wrong");
+    baseAction["failSpinner"]("Failure", error);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Error:"));
+    expect(consoleSpy).toHaveBeenCalledWith(inspect(error, {depth: null, colors: false}));
+    expect(consoleSpy).toHaveBeenCalledWith("");
     expect(mockSpinner.fail).toHaveBeenCalledWith(expect.stringContaining("Failure"));
   });
 
@@ -108,7 +115,7 @@ describe("BaseAction", () => {
     baseAction["logSuccess"]("Success message", data);
 
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("✔ Success message"));
-    expect(consoleSpy).toHaveBeenCalledWith(chalk.green(JSON.stringify(data, null, 2)));
+    expect(consoleSpy).toHaveBeenCalledWith(chalk.green(inspect(data, {depth: null, colors: false})));
   });
 
   test("should log an error message with error details", () => {
@@ -117,18 +124,7 @@ describe("BaseAction", () => {
     baseAction["logError"]("Error message", error);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("✖ Error message"));
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      chalk.red(
-        JSON.stringify(
-          {
-            name: error.name,
-            message: error.message,
-          },
-          null,
-          2,
-        ),
-      ),
-    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(chalk.red(inspect(error, {depth: null, colors: false})));
   });
 
   test("should log an info message with data", () => {
@@ -137,7 +133,7 @@ describe("BaseAction", () => {
     baseAction["logInfo"]("Info message", data);
 
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("ℹ Info message"));
-    expect(consoleSpy).toHaveBeenCalledWith(chalk.blue(JSON.stringify(data, null, 2)));
+    expect(consoleSpy).toHaveBeenCalledWith(chalk.blue(inspect(data, {depth: null, colors: false})));
   });
 
   test("should log a warning message with data", () => {
@@ -146,7 +142,7 @@ describe("BaseAction", () => {
     baseAction["logWarning"]("Warning message", data);
 
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("⚠ Warning message"));
-    expect(consoleSpy).toHaveBeenCalledWith(chalk.yellow(JSON.stringify(data, null, 2)));
+    expect(consoleSpy).toHaveBeenCalledWith(chalk.yellow(inspect(data, {depth: null, colors: false})));
   });
 
   test("should succeed the spinner with a message and log result if data is provided", () => {
@@ -155,23 +151,9 @@ describe("BaseAction", () => {
     baseAction["succeedSpinner"]("Success", mockData);
 
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Result:"));
-    expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(mockData, null, 2));
+    expect(consoleSpy).toHaveBeenCalledWith(inspect(mockData, {depth: null, colors: false}));
+    expect(consoleSpy).toHaveBeenCalledWith("");
     expect(mockSpinner.succeed).toHaveBeenCalledWith(expect.stringContaining("Success"));
-  });
-
-  test("should format an Error instance with name, message, and additional properties", () => {
-    const error = new Error("Something went wrong");
-    (error as any).code = 500;
-
-    const result = (baseAction as any).formatOutput(error);
-    expect(result).toBe(JSON.stringify({name: "Error", message: "Something went wrong", code: 500}, null, 2));
-  });
-
-  test("should format an object as JSON string", () => {
-    const data = {key: "value", num: 42};
-    const result = (baseAction as any).formatOutput(data);
-
-    expect(result).toBe(JSON.stringify(data, null, 2));
   });
 
   test("should return a string representation of a primitive", () => {
@@ -179,28 +161,6 @@ describe("BaseAction", () => {
     expect((baseAction as any).formatOutput(42)).toBe("42");
     expect((baseAction as any).formatOutput(true)).toBe("true");
   });
-
-  test("should format a Map object correctly", () => {
-    const testMap = new Map<string, any>([
-      ["key1", "value1"],
-      ["key2", 42],
-      ["key3", {nested: "object"}],
-    ]);
-
-    const result = (baseAction as any).formatOutput(testMap);
-    const expected = JSON.stringify(
-      {
-        key1: "value1",
-        key2: 42,
-        key3: {nested: "object"},
-      },
-      null,
-      2,
-    );
-
-    expect(result).toBe(expected);
-  });
-
   const mockPrivateKey = "mocked_private_key";
 
   beforeEach(() => {
@@ -239,5 +199,35 @@ describe("BaseAction", () => {
     });
 
     await expect(baseAction["getPrivateKey"]()).rejects.toThrow("process exited");
+  });
+
+  describe("formatOutput", () => {
+    test("should return string as is", () => {
+      expect((baseAction as any).formatOutput("Hello")).toBe("Hello");
+    });
+
+    test("should format an object using util.inspect", () => {
+      const data = {key: "value", num: 42};
+      const result = (baseAction as any).formatOutput(data);
+      expect(result).toBe(inspect(data, {depth: null, colors: false}));
+    });
+
+    test("should format an error object using util.inspect", () => {
+      const error = new Error("Test Error");
+      const result = (baseAction as any).formatOutput(error);
+      expect(result).toBe(inspect(error, {depth: null, colors: false}));
+    });
+
+    test("should format a Map object using util.inspect", () => {
+      const testMap = new Map([["key1", "value1"]]);
+      const result = (baseAction as any).formatOutput(testMap);
+      expect(result).toBe(inspect(testMap, {depth: null, colors: false}));
+    });
+
+    test("should format a BigInt object using util.inspect", () => {
+      const bigIntValue = BigInt(9007199254740991);
+      const result = (baseAction as any).formatOutput(bigIntValue);
+      expect(result).toBe(inspect(bigIntValue, {depth: null, colors: false}));
+    });
   });
 });

--- a/tests/libs/baseAction.test.ts
+++ b/tests/libs/baseAction.test.ts
@@ -161,6 +161,7 @@ describe("BaseAction", () => {
     expect((baseAction as any).formatOutput(42)).toBe("42");
     expect((baseAction as any).formatOutput(true)).toBe("true");
   });
+
   const mockPrivateKey = "mocked_private_key";
 
   beforeEach(() => {
@@ -206,28 +207,28 @@ describe("BaseAction", () => {
       expect((baseAction as any).formatOutput("Hello")).toBe("Hello");
     });
 
-    test("should format an object using util.inspect", () => {
+    test("should format an object", () => {
       const data = {key: "value", num: 42};
       const result = (baseAction as any).formatOutput(data);
-      expect(result).toBe(inspect(data, {depth: null, colors: false}));
+      expect(result).toBe("{ key: 'value', num: 42 }");
     });
 
-    test("should format an error object using util.inspect", () => {
+    test("should format an error object", () => {
       const error = new Error("Test Error");
       const result = (baseAction as any).formatOutput(error);
-      expect(result).toBe(inspect(error, {depth: null, colors: false}));
+      expect(result).toContain("Error: Test Error");
     });
 
-    test("should format a Map object using util.inspect", () => {
+    test("should format a Map object", () => {
       const testMap = new Map([["key1", "value1"]]);
       const result = (baseAction as any).formatOutput(testMap);
-      expect(result).toBe(inspect(testMap, {depth: null, colors: false}));
+      expect(result).toBe("Map(1) { 'key1' => 'value1' }");
     });
 
-    test("should format a BigInt object using util.inspect", () => {
+    test("should format a BigInt object", () => {
       const bigIntValue = BigInt(9007199254740991);
       const result = (baseAction as any).formatOutput(bigIntValue);
-      expect(result).toBe(inspect(bigIntValue, {depth: null, colors: false}));
+      expect(result).toBe("9007199254740991n");
     });
   });
 });


### PR DESCRIPTION
The previous implementation for formatting log data involved custom logic to handle different data types, such as converting Map objects recursively and manually stringifying BigInt values. This approach was brittle and would require ongoing maintenance as new data types or edge cases were encountered.

To create a more robust and scalable solution, the custom formatting logic has been replaced with Node.js's native util.inspect(). This utility is purpose-built for object inspection, providing reliable serialization for a wide range of JavaScript types (including Error objects, BigInt, Date, etc.) and gracefully handling complex structures like circular references. This change simplifies the codebase and ensures consistent, readable output for any data passed to the logging methods.

Resolved Spinner Final-State Logging:

A workaround was implemented in the succeedSpinner and failSpinner methods by adding an empty console.log(''). This addresses a common terminal behavior where the final line of output from the spinner (the success or fail message) could be lost or overwritten upon completion. Inserting a blank line ensures that the final status message is always displayed correctly on a new line, preventing it from being visually truncated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the formatting of output messages for better readability and consistency across different data types.
  * Enhanced spinner messages to include clearer separation with additional blank lines.

* **Tests**
  * Updated and expanded test coverage to ensure consistent output formatting and proper handling of various data types in logs.
  * Added assertions to verify improved console output and blank line separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->