### PR TITLE
chore: add simulate write method command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^17.0.0",
         "ethers": "^6.13.4",
         "fs-extra": "^11.3.0",
-        "genlayer-js": "0.15.1",
+        "genlayer-js": "0.17.0",
         "inquirer": "^12.0.0",
         "keytar": "^7.9.0",
         "node-fetch": "^3.0.0",
@@ -5507,9 +5507,9 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.15.1.tgz",
-      "integrity": "sha512-Ys9p3FCgi6VWussoMtvSViHfWYrEabeKLO0TORnuNBDCty0lViZqNfrdGAh61sLrOw7ylf8WKvNX95NjVch6Og==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.17.0.tgz",
+      "integrity": "sha512-yMra04ZyZGxTkFsrOGxPpEibkausm4BQZ2D8/mZqhHRVe3rZK5NS6ptgmhDUq526Nyi0Ba3XeQUIPrr6HE2gNQ==",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^17.0.0",
     "ethers": "^6.13.4",
     "fs-extra": "^11.3.0",
-    "genlayer-js": "0.15.1",
+    "genlayer-js": "0.17.0",
     "inquirer": "^12.0.0",
     "keytar": "^7.9.0",
     "node-fetch": "^3.0.0",

--- a/src/commands/contracts/simulate.ts
+++ b/src/commands/contracts/simulate.ts
@@ -1,0 +1,50 @@
+import {BaseAction} from "../../lib/actions/BaseAction";
+
+export interface SimulateWriteOptions {
+  args: any[];
+  rpc?: string;
+  rawReturn?: boolean;
+  leaderOnly?: boolean;
+  transactionHashVariant?: string;
+}
+
+export class SimulateWriteAction extends BaseAction {
+  constructor() {
+    super();
+  }
+
+  async simulate({
+    contractAddress,
+    method,
+    args,
+    rpc,
+    rawReturn,
+    leaderOnly,
+    transactionHashVariant,
+  }: {
+    contractAddress: string;
+    method: string;
+    args: any[];
+    rpc?: string;
+    rawReturn?: boolean;
+    leaderOnly?: boolean;
+    transactionHashVariant?: string;
+  }): Promise<void> {
+    const client = await this.getClient(rpc, true);
+    this.startSpinner(`Simulating write method ${method} on contract at ${contractAddress}...`);
+
+    try {
+      const result = await client.simulateWriteContract({
+        address: contractAddress as any,
+        functionName: method,
+        args,
+        rawReturn,
+        leaderOnly,
+        transactionHashVariant: transactionHashVariant as any,
+      } as any);
+      this.succeedSpinner("Simulation executed successfully", result);
+    } catch (error) {
+      this.failSpinner("Error during write simulation", error);
+    }
+  }
+} 

--- a/tests/actions/simulate.action.test.ts
+++ b/tests/actions/simulate.action.test.ts
@@ -1,0 +1,74 @@
+import {describe, test, vi, beforeEach, afterEach, expect} from "vitest";
+import {createClient, createAccount} from "genlayer-js";
+import {SimulateWriteAction} from "../../src/commands/contracts/simulate";
+
+vi.mock("genlayer-js");
+
+describe("SimulateWriteAction", () => {
+  let action: SimulateWriteAction;
+  const mockClient = {
+    simulateWriteContract: vi.fn(),
+  };
+
+  const mockPrivateKey = "mocked_private_key";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createClient).mockReturnValue(mockClient as any);
+    vi.mocked(createAccount).mockReturnValue({privateKey: mockPrivateKey} as any);
+    action = new SimulateWriteAction();
+
+    vi.spyOn(action as any, "getAccount").mockResolvedValue({privateKey: mockPrivateKey});
+
+    vi.spyOn(action as any, "startSpinner").mockImplementation(() => {});
+    vi.spyOn(action as any, "succeedSpinner").mockImplementation(() => {});
+    vi.spyOn(action as any, "failSpinner").mockImplementation(() => {});
+    vi.spyOn(action as any, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("calls simulateWriteContract with all options and read-only client", async () => {
+    vi.mocked(mockClient.simulateWriteContract).mockResolvedValue("ok");
+
+    await action.simulate({
+      contractAddress: "0x123",
+      method: "doThing",
+      args: [7, "x", true],
+      rpc: "http://rpc",
+      rawReturn: true,
+      leaderOnly: true,
+      transactionHashVariant: "legacy",
+    });
+
+    // getClient called with readOnly=true
+    const getClientSpy = vi.spyOn(action as any, "getClient");
+    expect(getClientSpy).not.toBeNull();
+
+    expect(mockClient.simulateWriteContract).toHaveBeenCalledWith({
+      address: "0x123",
+      functionName: "doThing",
+      args: [7, "x", true],
+      rawReturn: true,
+      leaderOnly: true,
+      transactionHashVariant: "legacy",
+    });
+  });
+
+  test("handles simulateWriteContract errors gracefully", async () => {
+    vi.mocked(mockClient.simulateWriteContract).mockRejectedValue(new Error("boom"));
+
+    await action.simulate({
+      contractAddress: "0x999",
+      method: "fail",
+      args: [],
+    });
+
+    expect(action["failSpinner"]).toHaveBeenCalledWith(
+      "Error during write simulation",
+      expect.any(Error),
+    );
+  });
+}); 

--- a/tests/actions/simulate.action.test.ts
+++ b/tests/actions/simulate.action.test.ts
@@ -33,6 +33,9 @@ describe("SimulateWriteAction", () => {
   test("calls simulateWriteContract with all options and read-only client", async () => {
     vi.mocked(mockClient.simulateWriteContract).mockResolvedValue("ok");
 
+    // Setup getClient spy before calling simulate()
+    const getClientSpy = vi.spyOn(action as any, "getClient").mockResolvedValue(mockClient);
+
     await action.simulate({
       contractAddress: "0x123",
       method: "doThing",
@@ -43,9 +46,8 @@ describe("SimulateWriteAction", () => {
       transactionHashVariant: "legacy",
     });
 
-    // getClient called with readOnly=true
-    const getClientSpy = vi.spyOn(action as any, "getClient");
-    expect(getClientSpy).not.toBeNull();
+    // Assert getClient was called with correct arguments
+    expect(getClientSpy).toHaveBeenCalledWith("http://rpc", true);
 
     expect(mockClient.simulateWriteContract).toHaveBeenCalledWith({
       address: "0x123",
@@ -55,6 +57,9 @@ describe("SimulateWriteAction", () => {
       leaderOnly: true,
       transactionHashVariant: "legacy",
     });
+
+    // Assert succeedSpinner was called on success
+    expect((action as any).succeedSpinner).toHaveBeenCalled();
   });
 
   test("handles simulateWriteContract errors gracefully", async () => {

--- a/tests/commands/write.simulate.test.ts
+++ b/tests/commands/write.simulate.test.ts
@@ -1,0 +1,77 @@
+import {Command} from "commander";
+import {vi, describe, beforeEach, afterEach, test, expect} from "vitest";
+import {initializeContractsCommands} from "../../src/commands/contracts";
+import {WriteAction} from "../../src/commands/contracts/write";
+import {SimulateWriteAction} from "../../src/commands/contracts/simulate";
+import {getCommand, getCommandOption} from "../utils";
+
+vi.mock("../../src/commands/contracts/write");
+vi.mock("../../src/commands/contracts/simulate");
+vi.mock("esbuild", () => ({
+  buildSync: vi.fn(),
+}));
+
+describe("write command simulate routing", () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    initializeContractsCommands(program);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("write command exposes simulate-related options", () => {
+    const writeCmd = getCommand(program, "write");
+    expect(getCommandOption(writeCmd, "--simulate")).toBeDefined();
+    expect(getCommandOption(writeCmd, "--rawReturn")).toBeDefined();
+    expect(getCommandOption(writeCmd, "--leaderOnly")).toBeDefined();
+    expect(getCommandOption(writeCmd, "--transactionHashVariant")).toBeDefined();
+  });
+
+  test("routes to SimulateWriteAction when --simulate is provided and passes flags", async () => {
+    program.parse([
+      "node",
+      "test",
+      "write",
+      "0xDef",
+      "setFlag",
+      "--simulate",
+      "--rpc",
+      "http://localhost:8080",
+      "--args",
+      "1",
+      "false",
+      "--rawReturn",
+      "--leaderOnly",
+      "--transactionHashVariant",
+      "legacy",
+    ]);
+
+    expect(SimulateWriteAction).toHaveBeenCalledTimes(1);
+    expect(SimulateWriteAction.prototype.simulate).toHaveBeenCalledWith({
+      contractAddress: "0xDef",
+      method: "setFlag",
+      args: [1, false],
+      rpc: "http://localhost:8080",
+      rawReturn: true,
+      leaderOnly: true,
+      transactionHashVariant: "legacy",
+    });
+  });
+
+  test("routes to WriteAction when --simulate is not provided", async () => {
+    program.parse(["node", "test", "write", "0xAbc", "setValue", "--args", "42", "hello", "true"]);
+
+    expect(WriteAction).toHaveBeenCalledTimes(1);
+    expect(WriteAction.prototype.write).toHaveBeenCalledWith({
+      contractAddress: "0xAbc",
+      method: "setValue",
+      args: [42, "hello", true],
+      rpc: undefined,
+    });
+  });
+}); 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a simulation mode for contract write operations via a new --simulate option to preview results without sending a transaction.
  * Added advanced flags: --rawReturn (unprocessed output), --leaderOnly (target leader node), and --transactionHashVariant (choose hash format).
  * CLI now shows clearer success/failure feedback for simulations; normal write, deploy, call, and schema behavior unchanged.

* **Tests**
  * Added unit tests verifying simulation routing, option handling, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->