### PR TITLE
fix: align Gemini provider naming with backend database schema

### DIFF
--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -23,7 +23,7 @@ export type RunningPlatform = (typeof AVAILABLE_PLATFORMS)[number];
 export const STARTING_TIMEOUT_WAIT_CYLCE = 2000;
 export const STARTING_TIMEOUT_ATTEMPTS = 120;
 
-export type AiProviders = "ollama" | "openai" | "heuristai" | "geminiai" | "xai";
+export type AiProviders = "ollama" | "openai" | "heuristai" | "google" | "xai";
 export type AiProvidersEnvVars = "ollama" | "OPENAIKEY" | "HEURISTAIAPIKEY" | "GEMINI_API_KEY" | "XAI_API_KEY";
 export type AiProvidersConfigType = {
   [key in AiProviders]: {name: string; hint: string; envVar?: AiProvidersEnvVars; cliOptionValue: string};
@@ -47,11 +47,11 @@ export const AI_PROVIDERS_CONFIG: AiProvidersConfigType = {
     envVar: "HEURISTAIAPIKEY",
     cliOptionValue: "heuristai",
   },
-  geminiai: {
+  google: {
     name: "Gemini",
     hint: '(You will need to provide an API key.)',
     envVar: "GEMINI_API_KEY",
-    cliOptionValue: "geminiai",
+    cliOptionValue: "google",
   },
   xai: {
     name: "XAI",


### PR DESCRIPTION
The CLI was using 'geminiai' as the provider identifier, but the backend's llm_provider table uses 'google' for Gemini models. This mismatch caused validator creation to fail with 'Requested providers do not match any stored providers' error.

Changes:
- src/lib/config/simulator.ts (L26): Update AiProviders type definition from 'geminiai' to 'google'
- src/lib/config/simulator.ts (L50-L54): Update AI_PROVIDERS_CONFIG object key and cliOptionValue from 'geminiai' to 'google'

This ensures the CLI sends provider names that match the backend's database records, allowing successful validator initialization with Gemini models.

Resolves provider validation error during 'genlayer init' workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI provider naming convention from "geminiai" to "google" in configurations. Users referencing "geminiai" must update to "google" to maintain compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->