### PR TITLE
fix: upgrade genlayer-js to 0.20.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dotenv": "^17.0.0",
         "ethers": "^6.13.4",
         "fs-extra": "^11.3.0",
-        "genlayer-js": "^0.18.10",
+        "genlayer-js": "^0.20.2",
         "inquirer": "^12.0.0",
         "keytar": "^7.9.0",
         "node-fetch": "^3.0.0",
@@ -5581,9 +5581,9 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "0.18.10",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.18.10.tgz",
-      "integrity": "sha512-/femmDnoGMm9fTotobkqTndOE//UcJWY1QYLQFueE/rE25shL77vCjKWtg/hj0U8xxg26Mksfjcr/crO22i5kA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.20.2.tgz",
+      "integrity": "sha512-c5UI5sZ6rIteEWBsv+d7f0oYyQaIPPPO2GeCVIg+jcLbsp/cKH886vo1Mc4y5qTaOlg3LPZDqqgN3uza6PgaZw==",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dotenv": "^17.0.0",
     "ethers": "^6.13.4",
     "fs-extra": "^11.3.0",
-    "genlayer-js": "^0.18.10",
+    "genlayer-js": "^0.20.2",
     "inquirer": "^12.0.0",
     "keytar": "^7.9.0",
     "node-fetch": "^3.0.0",


### PR DESCRIPTION
## Summary
- Upgrades `genlayer-js` from `^0.18.10` to `^0.20.2`
- v0.20.2 fixes silent data loss when reading Python dicts from contracts — `readContract()` now defaults `jsonSafeReturn` to `true`, so dicts are returned as plain objects instead of JS `Map` objects (which serialize to `{}` via `JSON.stringify`)

## Test plan
- [x] All 437 CLI tests pass locally
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated genlayer-js dependency from ^0.18.10 to ^0.20.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->