### PR TITLE
fix: rename gemini provider from 'geminiai' to 'google' to match backend

### DIFF
--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -23,7 +23,7 @@ export type RunningPlatform = (typeof AVAILABLE_PLATFORMS)[number];
 export const STARTING_TIMEOUT_WAIT_CYLCE = 2000;
 export const STARTING_TIMEOUT_ATTEMPTS = 120;
 
-export type AiProviders = "ollama" | "openai" | "heuristai" | "geminiai" | "xai";
+export type AiProviders = "ollama" | "openai" | "heuristai" | "google" | "xai";
 export type AiProvidersEnvVars = "ollama" | "OPENAIKEY" | "HEURISTAIAPIKEY" | "GEMINI_API_KEY" | "XAI_API_KEY";
 export type AiProvidersConfigType = {
   [key in AiProviders]: {name: string; hint: string; envVar?: AiProvidersEnvVars; cliOptionValue: string};
@@ -47,11 +47,11 @@ export const AI_PROVIDERS_CONFIG: AiProvidersConfigType = {
     envVar: "HEURISTAIAPIKEY",
     cliOptionValue: "heuristai",
   },
-  geminiai: {
+  google: {
     name: "Gemini",
     hint: '(You will need to provide an API key.)',
     envVar: "GEMINI_API_KEY",
-    cliOptionValue: "geminiai",
+    cliOptionValue: "google",
   },
   xai: {
     name: "XAI",


### PR DESCRIPTION
Fixes #271

## Problem
When running `genlayer init` and selecting Gemini as the LLM provider, initialization fails with:
```
Error: Requested providers {geminiai} do not match any stored providers.
```

## Root Cause
- CLI sends: `geminiai`
- Backend expects: `google`

Verified in genlayer-studio:
- `backend/node/create_nodes/default_providers/google_gemini-*.json`: `"provider": "google"`
- `tests/integration/test_llm_providers_registry.py`: `"google": "GEMINI_API_KEY"`
- `frontend/src/assets/schemas/providers_schema.json`: enum includes `"google"`

## Changes
- Rename provider key from `geminiai` to `google` in `AI_PROVIDERS_CONFIG`
- Update `AiProviders` type to use `google` instead of `geminiai`
- `cliOptionValue` now sends `google` to match backend expectations

## Files Changed
- `src/lib/config/simulator.ts` (3 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the AI provider identifier used in configuration and CLI from "geminiai" to "google".
  * The provider will continue to display as "Gemini" and the existing Gemini environment variable remains unchanged.
  * This adjusts provider selection and CLI option mapping to use the new identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->