### PR TITLE
fix: Update Gemini provider name from geminiai to google

### DIFF
--- a/src/lib/config/simulator.ts
+++ b/src/lib/config/simulator.ts
@@ -23,7 +23,7 @@ export type RunningPlatform = (typeof AVAILABLE_PLATFORMS)[number];
 export const STARTING_TIMEOUT_WAIT_CYLCE = 2000;
 export const STARTING_TIMEOUT_ATTEMPTS = 120;
 
-export type AiProviders = "ollama" | "openai" | "heuristai" | "geminiai" | "xai";
+export type AiProviders = "ollama" | "openai" | "heuristai" | "google" | "xai";
 export type AiProvidersEnvVars = "ollama" | "OPENAIKEY" | "HEURISTAIAPIKEY" | "GEMINI_API_KEY" | "XAI_API_KEY";
 export type AiProvidersConfigType = {
   [key in AiProviders]: {name: string; hint: string; envVar?: AiProvidersEnvVars; cliOptionValue: string};
@@ -47,11 +47,11 @@ export const AI_PROVIDERS_CONFIG: AiProvidersConfigType = {
     envVar: "HEURISTAIAPIKEY",
     cliOptionValue: "heuristai",
   },
-  geminiai: {
+  google: {
     name: "Gemini",
     hint: '(You will need to provide an API key.)',
     envVar: "GEMINI_API_KEY",
-    cliOptionValue: "geminiai",
+    cliOptionValue: "google",
   },
   xai: {
     name: "XAI",


### PR DESCRIPTION
## Problem
When users run `genlayer init` and select Gemini as their LLM provider, initialization fails with:

Error: Requested providers '{'geminiai'}' do not match any stored providers.
Please review your stored providers.


## Root Cause
**Provider name mismatch between CLI and backend:**
- CLI was sending: `geminiai`
- Backend database expects: `google`

The backend's `llm_provider` database table uses `provider = 'google'` for Gemini, but the CLI configuration was set to send `geminiai`.

## Solution
Updated the CLI's `AI_PROVIDERS_CONFIG` in `src/lib/config/simulator.ts`:
- Changed `cliOptionValue: "geminiai"` to `cliOptionValue: "google"`

## Changes
- **File:** `src/lib/config/simulator.ts`
- **Change:** Line 54: `cliOptionValue: "geminiai",` → `cliOptionValue: "google",`

## Testing
To verify the fix:
1. Run `genlayer init --numValidators 3`
2. When prompted, select "Gemini" as the LLM provider
3. Enter a valid Gemini API key
4. Initialization should complete successfully

Fixes #271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed the Gemini AI provider identifier from `geminiai` to `google` in configuration and CLI options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->