### PR TITLE
feat: Implement get account balance command (#56)

### DIFF
--- a/src/commands/account/balance.ts
+++ b/src/commands/account/balance.ts
@@ -1,0 +1,69 @@
+import {BaseAction, resolveNetwork} from "../../lib/actions/BaseAction";
+import {formatEther} from "viem";
+import {createClient} from "genlayer-js";
+import type {GenLayerChain, Address} from "genlayer-js/types";
+import {readFileSync, existsSync} from "fs";
+
+export interface GetBalanceOptions {
+  rpc?: string;
+  account?: string;
+}
+
+export class GetBalanceAction extends BaseAction {
+  constructor() {
+    super();
+  }
+
+  private getNetwork(): GenLayerChain {
+    return resolveNetwork(this.getConfig().network);
+  }
+
+  async execute(options?: GetBalanceOptions): Promise<void> {
+    this.startSpinner("Fetching account balance...");
+
+    try {
+      if (options?.account) {
+        this.accountOverride = options.account;
+      }
+
+      const accountName = this.resolveAccountName();
+      const keystorePath = this.getKeystorePath(accountName);
+
+      if (!existsSync(keystorePath)) {
+        this.failSpinner(`Account '${accountName}' not found. Run 'genlayer account create --name ${accountName}' first.`);
+        return;
+      }
+
+      const keystoreData = JSON.parse(readFileSync(keystorePath, "utf-8"));
+
+      if (!this.isValidKeystoreFormat(keystoreData)) {
+        this.failSpinner("Invalid keystore format.");
+        return;
+      }
+
+      const rawAddr = keystoreData.address;
+      const address = (rawAddr.startsWith("0x") ? rawAddr : `0x${rawAddr}`) as Address;
+      const network = this.getNetwork();
+
+      const client = createClient({
+        chain: network,
+        account: address,
+        endpoint: options?.rpc,
+      });
+
+      const balance = await client.getBalance({address});
+      const formattedBalance = formatEther(balance);
+
+      const result = {
+        account: accountName,
+        address,
+        balance: `${formattedBalance} GEN`,
+        network: network.name || "localnet",
+      };
+
+      this.succeedSpinner("Account balance", result);
+    } catch (error: any) {
+      this.failSpinner("Failed to get account balance", error.message || error);
+    }
+  }
+}

--- a/src/commands/account/index.ts
+++ b/src/commands/account/index.ts
@@ -6,6 +6,8 @@ import {ExportAccountAction, ExportAccountOptions} from "./export";
 import {UnlockAccountAction, UnlockAccountOptions} from "./unlock";
 import {LockAccountAction, LockAccountOptions} from "./lock";
 import {SendAction, SendOptions} from "./send";
+import {GetBalanceAction, GetBalanceOptions} from "./balance";
+import {FundAccountAction, FundAccountOptions} from "./fund";
 import {ListAccountsAction} from "./list";
 import {UseAccountAction} from "./use";
 import {RemoveAccountAction} from "./remove";
@@ -36,6 +38,16 @@ export function initializeAccountCommands(program: Command) {
     .action(async (options: ShowAccountOptions) => {
       const showAction = new ShowAccountAction();
       await showAction.execute(options);
+    });
+
+  accountCommand
+    .command("balance")
+    .description("Get account balance")
+    .option("--rpc <rpcUrl>", "RPC URL for the network")
+    .option("--account <name>", "Account to check balance for")
+    .action(async (options: GetBalanceOptions) => {
+      const balanceAction = new GetBalanceAction();
+      await balanceAction.execute(options);
     });
 
   accountCommand


### PR DESCRIPTION


Implements the `genlayer account balance` command to allow users to easily check their account balance without needing to view the full account details.

## Changes

- Added `GetBalanceAction` class in `src/commands/account/balance.ts`
- Registered `balance` subcommand under the `account` command group
- Updated `src/commands/account/index.ts` with imports and command registration

## Usage

```bash
# Get balance for active account
genlayer account balance

# Get balance for specific account
genlayer account balance --account myaccount

# Get balance from custom RPC endpoint
genlayer account balance --rpc http://custom-rpc:4000/api