### PR TITLE
ci: drop self-push of generated docs back to CLI repo

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -14,18 +14,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.DOCS_SYNC_APP_CLIENT_ID }}
-          private-key: ${{ secrets.DOCS_SYNC_APP_KEY }}
-          repositories: genlayer-cli,genlayer-docs
-
       - name: Checkout CLI repo
         uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -55,23 +45,13 @@ jobs:
           DOCS_VERSION: ${{ steps.version.outputs.value }}
         run: node scripts/generate-cli-docs.mjs | cat
 
-      - name: Set up Git (for committing to CLI repo)
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Commit and push docs back to CLI repo (non-beta releases)
-        if: github.event_name == 'release' && !contains(github.event.release.tag_name, '-')
-        run: |
-          set -euo pipefail
-          if [ -n "$(git status --porcelain docs/api-references || true)" ]; then
-            git add docs/api-references
-            VERSION=${{ steps.version.outputs.value }}
-            git commit -m "docs(cli): update API reference for ${VERSION}"
-            git push origin HEAD:main
-          else
-            echo "No docs changes to commit"
-          fi
+      - name: Generate docs repo token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.DOCS_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DOCS_SYNC_APP_KEY }}
+          repositories: genlayer-docs
 
       - name: Checkout docs repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The \"Commit and push docs back to CLI repo\" step in `sync-docs.yml` has never successfully produced a commit. Every `release`-triggered run has failed at the `git push` due to detached HEAD on the tag ref (e.g. [run 24839331459](https://github.com/genlayerlabs/genlayer-cli/actions/runs/24839331459)), and the step is gated to `release` events so no other trigger exercises it. The 3 existing commits in `docs/api-references/` on `main` are all hand-authored.

The canonical CLI docs sync to `genlayer-docs` is the useful output of this workflow and continues to work unchanged.

## What this PR does

- Removes the \"Set up Git (for committing to CLI repo)\" step
- Removes the \"Commit and push docs back to CLI repo (non-beta releases)\" step
- Reverts the App-token plumbing added on the initial CLI checkout in #297 (no longer needed)
- Returns the Sync-docs App token scope to `genlayer-docs` only

## Why removing instead of fixing

Making the self-push work would require:
- Installing the Sync-docs app on `genlayer-cli` (expanding its blast radius)
- Adding the Sync-docs app to `main` branch-protection bypass list
- Pushing to `origin HEAD:main` (detached HEAD fix)

For an output that has no consumer — the canonical docs live in `genlayer-docs` — the cost/benefit doesn't justify it. If a snapshot in this repo is ever wanted later, the prior PR-based approach (`peter-evans/create-pull-request`) is a safer fallback.

## Test plan

- [ ] Dispatch the workflow on `main` post-merge and confirm the genlayer-docs sync still succeeds (the only path now)