### PR TITLE
ci: revert publish env name to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: Publish
+    environment: npm
     steps:
       - name: Get CI Bot Token
         uses: actions/create-github-app-token@v3


### PR DESCRIPTION
## Summary

Reverts the `npm` → `Publish` rename from #297. The npm trusted publisher config registered on npmjs.org for the `genlayer` package pins the `environment` claim to `npm`, so renaming the GitHub env broke OIDC auth and `npm publish` started returning 404 (see [run 25439947012](https://github.com/genlayerlabs/genlayer-cli/actions/runs/25439947012) — provenance signed, trusted-publisher match failed).

## Pre-merge checklist (GitHub side)

- [ ] Recreate `npm` environment with:
  - Variable `PUBLISH_CI_APP_CLIENT_ID` = same value as currently in `Publish`
  - Secret `PUBLISH_CI_APP_KEY` = same value as currently in `Publish`
  - Deployment branch policy: `main` (and `staging` if needed for beta)
  - Required reviewers as desired
- [ ] Delete the `Publish` environment after the new `npm` env is in place

## Test plan

- [ ] After merge, push a `fix:` or `feat:` commit to `main` (or trigger the workflow manually) and confirm npm publish succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to use npm environment for deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->