### PR TITLE
fix(base-action): move misplaced imports to top of file

### DIFF
--- a/src/lib/actions/BaseAction.ts
+++ b/src/lib/actions/BaseAction.ts
@@ -4,6 +4,8 @@ import ora, {Ora} from "ora";
 import chalk from "chalk";
 import inquirer from "inquirer";
 import { inspect } from "util";
+import { ethers } from "ethers";
+import { writeFileSync, existsSync, readFileSync } from "fs";
 import {createClient, createAccount} from "genlayer-js";
 import {localnet, studionet, testnetAsimov, testnetBradbury} from "genlayer-js/chains";
 import type {GenLayerClient, GenLayerChain, Hash, Address, Account} from "genlayer-js/types";
@@ -43,8 +45,6 @@ export function resolveNetwork(stored: string | undefined): GenLayerChain {
     throw new Error(`Unknown network: ${stored}`);
   }
 }
-import { ethers } from "ethers";
-import { writeFileSync, existsSync, readFileSync } from "fs";
 
 export class BaseAction extends ConfigFileManager {
   private static readonly DEFAULT_ACCOUNT_NAME = "default";


### PR DESCRIPTION
## Summary

`src/lib/actions/BaseAction.ts` had two import statements (`ethers` and the `fs` helpers) sitting between the `resolveNetwork` function and the `BaseAction` class declaration, instead of with the rest of the imports at the top of the file. This PR just moves them up.

## Why it matters

It looks like a leftover from a merge or refactor. The risks if it stays:

* Anyone adding the same imports at the top of the file gets a duplicate import and won't notice until the bundler/linter complains.
* Import-scanning tools (and a quick visual scan during review) miss them where they are now.
* No functional impact today, but it's the kind of thing that breaks the moment someone touches the file.

## Changes

* Moved `import { ethers } from "ethers";` and `import { writeFileSync, existsSync, readFileSync } from "fs";` from lines 46-47 to the top import block.

## Verification

* `npm test` — 504 tests passing across 47 files.
* `npm run build` — production esbuild succeeds.

Closes #307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no impact on functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-cli/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->