### PR TITLE
fix(config): remove dead local delete in reset

### DIFF
--- a/src/commands/config/getSetReset.ts
+++ b/src/commands/config/getSetReset.ts
@@ -44,7 +44,6 @@ export class ConfigActions extends BaseAction {
       return;
     }
 
-    delete config[key];
     this.writeConfig(key, undefined);
     this.succeedSpinner(`Configuration successfully reset`);
   }


### PR DESCRIPTION
## Summary

`ConfigActions.reset` did `delete config[key]` on the object returned by `getConfig()`, but that object is local and immediately discarded. The actual persistence happens via `writeConfig(key, undefined)` on the next line, which reads its own fresh copy from disk.

So the `delete` does nothing today, and it's actively misleading: someone refactoring this method could reasonably assume the deletion is part of the persistence path and break the reset flow.

## Changes

* Drop the dead `delete config[key]` from `src/commands/config/getSetReset.ts`.

## Verification

* `npx vitest run tests/actions/getSetReset.test.ts` — 7 tests passing.
* Existing tests only assert that `writeConfig` is called with `(key, undefined)` and the success message fires, both of which still hold.

Closes #305