### PR TITLE
fix(network): route empty string to interactive prompt in setNetwork

### DIFF
--- a/src/commands/network/setNetwork.ts
+++ b/src/commands/network/setNetwork.ts
@@ -44,7 +44,7 @@ export class NetworkActions extends BaseAction {
   }
 
   async setNetwork(networkName?: string): Promise<void> {
-    if (networkName || networkName === "") {
+    if (networkName) {
       if (!networks.some(n => n.name === networkName || n.alias === networkName)) {
         this.failSpinner(`Network ${networkName} not found`);
         return;

--- a/tests/actions/setNetwork.test.ts
+++ b/tests/actions/setNetwork.test.ts
@@ -85,12 +85,19 @@ describe("NetworkActions", () => {
     expect(networkActions["succeedSpinner"]).not.toHaveBeenCalled();
   });
 
-  test("setNetwork method fails for empty network name", async () => {
+  test("setNetwork method falls back to interactive prompt for empty network name", async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      selectedNetwork: "localnet",
+    });
+
     await networkActions.setNetwork("");
 
-    expect(networkActions["failSpinner"]).toHaveBeenCalledWith("Network  not found");
-    expect(networkActions["writeConfig"]).not.toHaveBeenCalled();
-    expect(networkActions["succeedSpinner"]).not.toHaveBeenCalled();
+    expect(inquirer.prompt).toHaveBeenCalled();
+    expect(networkActions["failSpinner"]).not.toHaveBeenCalled();
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith("network", "localnet");
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${localnet.name}`,
+    );
   });
 
   test("setNetwork method prompts user when no network name provided", async () => {


### PR DESCRIPTION
## Summary

`NetworkActions.setNetwork` had `if (networkName || networkName === "")`, which sends an empty string into the lookup branch. The lookup obviously fails, and the user sees:

```
Network  not found
```

with a blank space where the network name should be. The interactive picker is never shown, even though that's clearly what should happen when no usable argument was supplied.

This treats empty string the same as no argument — drop into the prompt.

## Reproduce

```
genlayer network set ""
```

Before: `Network  not found`
After: interactive network picker

## Changes

* `src/commands/network/setNetwork.ts`: change condition from `if (networkName || networkName === "")` to `if (networkName)`.
* `tests/actions/setNetwork.test.ts`: the existing test was asserting the buggy `"Network  not found"` message; rewrite it to expect the prompt fallback.

## Verification

* `npx vitest run tests/actions/setNetwork.test.ts tests/commands/network.test.ts` — 20 tests passing.

Closes #306