### PR TITLE
fix(system): throw on unparseable version instead of returning empty string

### DIFF
--- a/src/lib/clients/system.ts
+++ b/src/lib/clients/system.ts
@@ -50,24 +50,20 @@ export function openUrl(url: string): Promise<ChildProcess> {
 }
 
 export async function getVersion(toolName: string): Promise<string> {
+  let toolResponse;
   try {
-    const toolResponse = await util.promisify(exec)(`${toolName} --version`);
-
-    if (toolResponse.stderr) {
-      throw new Error(toolResponse.stderr);
-    }
-
-    try {
-      const versionMatch = toolResponse.stdout.match(/(\d+\.\d+\.\d+)/);
-      if (versionMatch) {
-        return versionMatch[1];
-      }
-    } catch (err) {
-      throw new Error(`Could not parse ${toolName} version.`);
-    }
-  } catch (error) {
+    toolResponse = await util.promisify(exec)(`${toolName} --version`);
+  } catch {
     throw new Error(`Error getting ${toolName} version.`);
   }
 
-  return "";
+  if (toolResponse.stderr) {
+    throw new Error(`Error getting ${toolName} version.`);
+  }
+
+  const versionMatch = toolResponse.stdout?.match(/(\d+\.\d+\.\d+)/);
+  if (versionMatch) {
+    return versionMatch[1];
+  }
+  throw new Error(`Could not parse ${toolName} version from output: ${toolResponse.stdout}`);
 }

--- a/tests/libs/system.test.ts
+++ b/tests/libs/system.test.ts
@@ -70,21 +70,34 @@ describe("System Functions - Error Paths", () => {
     await expect(getVersion(toolName)).rejects.toThrow(`Error getting ${toolName} version.`);
   });
 
-  test("getVersion returns '' if stdout is empty", async () => {
+  test("getVersion throws when stdout has no version-shaped string", async () => {
     vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.resolve({
       stdout: "",
       stderr: ""
     }));
-    const result = await getVersion('git');
-    expect(result).toBe("");
+    await expect(getVersion('git')).rejects.toThrow(
+      "Could not parse git version from output: "
+    );
   });
 
-  test("getVersion throw error if stdout undefined", async () => {
+  test("getVersion throws when stdout is undefined", async () => {
     vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.resolve({
       stderr: ""
     }));
     const toolName = "nonexistent";
-    await expect(getVersion(toolName)).rejects.toThrow(`Error getting ${toolName} version.`);
+    await expect(getVersion(toolName)).rejects.toThrow(
+      `Could not parse ${toolName} version from output: undefined`
+    );
+  });
+
+  test("getVersion throws when stdout has output without a version pattern", async () => {
+    vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.resolve({
+      stdout: "git version v22-rc1",
+      stderr: ""
+    }));
+    await expect(getVersion('git')).rejects.toThrow(
+      "Could not parse git version from output: git version v22-rc1"
+    );
   });
 
   test("checkCommand returns false if the command does not exist", async () => {


### PR DESCRIPTION
## Summary

`getVersion` in `src/lib/clients/system.ts` had two problems stacked on each other:

1. If `toolResponse.stdout.match(/\d+\.\d+\.\d+/)` returned `null`, the function fell through to `return ""`.
2. The inner `try/catch` around `.match()` was dead — `String.prototype.match` doesn't throw, so the "Could not parse" branch was unreachable.

The empty string then flowed into `semver.satisfies("", ">=18.0.0")`, which is always `false`, so the user got a misleading "please update Docker/Node" error even when the tool was a perfectly fine version that just happened to print something the regex didn't recognise (e.g. `v22.0.0`, RC tags, exotic formats).

## Changes

`src/lib/clients/system.ts`:
* Split the exec call into its own `try` so the original error message ("Error getting <tool> version.") is preserved for that path.
* `stderr` still maps to the same generic failure.
* Removed the dead inner `try/catch`. If the regex doesn't match (including when `stdout` is `undefined`), throw a descriptive `Could not parse <tool> version from output: <stdout>` so callers and users actually see what came back.

`tests/libs/system.test.ts`:
* The existing `"returns '' if stdout is empty"` test was asserting the buggy behaviour — rewritten to expect the new throw.
* The `"throw error if stdout undefined"` test had the right intent but the wrong message — updated.
* Added a new case covering an output that has text but no `x.y.z` (the original repro from the issue).

## Verification

* `npx vitest run tests/libs/system.test.ts tests/services/simulator.test.ts` — 72 tests passing.

Closes #303