### PR TITLE
fix(system): treat any checkCommand exec failure as a missing tool

### DIFF
--- a/src/lib/clients/system.ts
+++ b/src/lib/clients/system.ts
@@ -8,10 +8,8 @@ import {MissingRequirementError} from "../errors/missingRequirement";
 export async function checkCommand(command: string, toolName: string): Promise<void> {
   try {
     await util.promisify(exec)(command);
-  }catch (error:any) {
-    if (error.stderr) {
-      throw new MissingRequirementError(toolName);
-    }
+  } catch {
+    throw new MissingRequirementError(toolName);
   }
 }
 

--- a/tests/libs/system.test.ts
+++ b/tests/libs/system.test.ts
@@ -96,6 +96,18 @@ describe("System Functions - Error Paths", () => {
     await expect(checkCommand(`${toolName} --version`, toolName)).rejects.toThrow(new MissingRequirementError(toolName));
   });
 
+  test("checkCommand throws MissingRequirementError when binary is missing (ENOENT)", async () => {
+    const enoent: any = Object.assign(new Error("spawn docker ENOENT"), {
+      code: "ENOENT",
+      stderr: undefined,
+    });
+    vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.reject(enoent));
+    const toolName = "docker";
+    await expect(checkCommand(`${toolName} --version`, toolName)).rejects.toThrow(
+      new MissingRequirementError(toolName),
+    );
+  });
+
   test("executeCommand throws an error if the command fails", async () => {
     vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.reject(new Error("Execution failed")));
     await expect(executeCommand({


### PR DESCRIPTION
## Summary

`checkCommand` only threw `MissingRequirementError` when the caught error had a non-empty `stderr`. When the binary itself is missing, `exec` rejects with `code: 'ENOENT'` and `stderr: undefined`, so the guard is false and the function resolves successfully.

That has a real downstream effect: `SimulatorService.checkInstallRequirements()` then sets `requirementsInstalled.docker = true` for users who don't have Docker installed at all. The follow-up `docker.ping()` crashes with a cryptic socket error instead of a clear "Docker is not installed" message.

## Reproduce

1. Uninstall Docker (or run on a clean machine).
2. `genlayer up`
3. Observe: CLI proceeds past the requirements check, then crashes on `docker.ping()`.

## Changes

`src/lib/clients/system.ts`:
* Drop the `if (error.stderr)` guard. Any rejection from `exec` means the tool isn't usable here, so just rethrow as `MissingRequirementError`. The caller (`checkInstallRequirements`) already special-cases `MissingRequirementError` vs. other errors.

`tests/libs/system.test.ts`:
* Added a regression test simulating the ENOENT rejection (no `stderr`).

## Verification

* `npx vitest run tests/libs/system.test.ts tests/services/simulator.test.ts` — 72 tests passing.

Closes #301