### PR TITLE
fix(account): verify keystore exists after create before reading it

### DIFF
--- a/src/lib/actions/BaseAction.ts
+++ b/src/lib/actions/BaseAction.ts
@@ -130,6 +130,10 @@ export class BaseAction extends ConfigFileManager {
     if (!existsSync(keystorePath)) {
       await this.confirmPrompt(`Account '${accountName}' not found. Would you like to create it?`);
       decryptedPrivateKey = await this.createKeypairByName(accountName, false);
+      if (!existsSync(keystorePath)) {
+        this.failSpinner(`Failed to create keystore file for account '${accountName}' at ${keystorePath}`);
+        throw new Error(`Keystore file was not created at ${keystorePath}`);
+      }
     }
 
     keystoreJson = readFileSync(keystorePath, "utf-8");

--- a/tests/libs/baseAction.test.ts
+++ b/tests/libs/baseAction.test.ts
@@ -305,7 +305,13 @@ describe("BaseAction", () => {
   });
 
   test("should create new keypair when keystore file does not exist", async () => {
-    vi.mocked(existsSync).mockReturnValue(false);
+    // First check: file missing, drop into create branch.
+    // createKeypairByName itself calls existsSync once (overwrite check) -> false.
+    // Post-create verification: file now exists.
+    vi.mocked(existsSync)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
     vi.mocked(inquirer.prompt)
       .mockResolvedValueOnce({confirmAction: true}) // confirm create new
       .mockResolvedValueOnce({password: "new-password"}) // encrypt password
@@ -317,6 +323,19 @@ describe("BaseAction", () => {
     expect(inquirer.prompt).toHaveBeenCalledWith(expect.arrayContaining([
       expect.objectContaining({message: chalk.yellow("Account 'default' not found. Would you like to create it?")})
     ]));
+  });
+
+  test("should surface a clear error when keystore creation does not produce the file", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(inquirer.prompt)
+      .mockResolvedValueOnce({confirmAction: true})
+      .mockResolvedValueOnce({password: "new-password"})
+      .mockResolvedValueOnce({password: "new-password"});
+
+    await expect(baseAction["getAccount"](false)).rejects.toThrow("process exited");
+    expect(mockSpinner.fail).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to create keystore file for account 'default'"),
+    );
   });
 
   test("should fail when keystore format is invalid and user declines", async () => {


### PR DESCRIPTION
## Summary

`BaseAction.getAccount` did this:

```ts
if (!existsSync(keystorePath)) {
  await this.confirmPrompt(...);
  decryptedPrivateKey = await this.createKeypairByName(accountName, false);
}

keystoreJson = readFileSync(keystorePath, "utf-8");   // unguarded
keystoreData = JSON.parse(keystoreJson);
```

If `createKeypairByName` returned without producing the keystore file on disk for any reason (disk full, EACCES, race condition), the very next line did an unconditional `readFileSync` and crashed with an unhandled `ENOENT`. The user got a stack trace instead of an explanation.

## Changes

`src/lib/actions/BaseAction.ts`:
* After the create attempt, verify the file actually exists. If not, surface "Failed to create keystore file for account '<name>' at <path>" via the spinner and throw an explicit error rather than falling into the read.

`tests/libs/baseAction.test.ts`:
* The existing "should create new keypair when keystore file does not exist" test mocked `existsSync` to return false on every call. With the post-create check that would now fail. Updated it so the post-create check sees the file.
* Added a regression test for the failure path: spinner shows the new message, function rejects.

## Verification

* `npx vitest run tests/libs/baseAction.test.ts` — 47 tests passing.

Closes #304