### PR TITLE
fix(account): stop retrying decryptKeystore on non-password errors

### DIFF
--- a/src/lib/actions/BaseAction.ts
+++ b/src/lib/actions/BaseAction.ts
@@ -71,12 +71,22 @@ export class BaseAction extends ConfigFileManager {
       const wallet = await ethers.Wallet.fromEncryptedJson(keystoreJson, password);
 
       return wallet.privateKey;
-    } catch (error) {
+    } catch (error: any) {
+      if (!BaseAction.isWrongPasswordError(error)) {
+        this.failSpinner(`Failed to decrypt keystore: ${error?.message ?? error}`);
+        throw error;
+      }
       if (attempt >= BaseAction.MAX_PASSWORD_ATTEMPTS) {
         this.failSpinner(`Maximum password attempts exceeded (${BaseAction.MAX_PASSWORD_ATTEMPTS}/${BaseAction.MAX_PASSWORD_ATTEMPTS}).`);
+        throw error;
       }
       return await this.decryptKeystore(keystoreJson, attempt + 1);
     }
+  }
+
+  private static isWrongPasswordError(error: any): boolean {
+    const message = String(error?.message ?? error ?? "").toLowerCase();
+    return message.includes("password") || message.includes("mac");
   }
 
   protected isValidKeystoreFormat(data: any): boolean {

--- a/tests/libs/baseAction.test.ts
+++ b/tests/libs/baseAction.test.ts
@@ -394,6 +394,23 @@ describe("BaseAction", () => {
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 
+  test("should not retry when the keystore is malformed (non-password error)", async () => {
+    vi.mocked(ethers.Wallet.fromEncryptedJson).mockRejectedValue(
+      new Error("Unexpected token in JSON at position 0"),
+    );
+    vi.mocked(inquirer.prompt).mockResolvedValue({password: "anything"});
+
+    await expect(baseAction["decryptKeystore"](JSON.stringify(mockKeystoreData))).rejects.toThrow();
+
+    expect(inquirer.prompt).toHaveBeenCalledTimes(1);
+    expect(mockSpinner.fail).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to decrypt keystore"),
+    );
+    expect(mockSpinner.fail).not.toHaveBeenCalledWith(
+      expect.stringContaining("Maximum password attempts exceeded"),
+    );
+  });
+
   test("should create new keypair successfully", async () => {
     vi.mocked(existsSync).mockReturnValue(false);
     vi.mocked(inquirer.prompt)


### PR DESCRIPTION
## Summary

`BaseAction.decryptKeystore` had three layered problems:

1. After `failSpinner("Maximum password attempts exceeded ...")` at attempt 3, the recursive call on the next line still ran. Today `failSpinner` exits the process so the recursion never actually happens, but the call site reads as live code and would loop forever the moment `shouldExit=false` were ever passed.
2. Any failure from `ethers.Wallet.fromEncryptedJson` was treated as a wrong password. A user with a corrupted keystore (bad JSON, missing crypto params, etc.) got prompted three times for a password they didn't get wrong, then a misleading "Maximum attempts exceeded" error.
3. No explicit return/throw after `failSpinner`, so the function's control flow relied entirely on the process-exit side effect.

## Changes

`src/lib/actions/BaseAction.ts`:
* Inspect the error before retrying. Only loop on errors whose message looks password-related (contains `password` or `mac` — the typical ethers shapes).
* Anything else surfaces a clear `Failed to decrypt keystore: <reason>` via the spinner and throws.
* Add explicit `throw` after both `failSpinner` calls so the contract holds even if `shouldExit=false` is ever passed.
* Pull the heuristic into a static helper `isWrongPasswordError` for clarity.

`tests/libs/baseAction.test.ts`:
* Existing tests use `"Incorrect password"` as the rejection message, which still matches the password-error heuristic, so they stay on the retry path.
* Added a new test for the corrupted-keystore case: spinner shows `Failed to decrypt keystore`, prompt is called only once, no `Maximum password attempts exceeded` message.

## Verification

* `npm test` — 505/505 passing across 47 files.

Closes #302