### PR TITLE
fix: run CI on v0.39 branch

### DIFF
--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -8,7 +8,7 @@ on:
       - reopened
   push:
     branches:
-      - main
+      - v0.39
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Summary

Updates the validate-code push trigger from retired `main` to the current stable `v0.39` branch.

The pull request trigger is already unfiltered and continues to run on PRs targeting `v0.39`.

## Verification

- `git diff --check`
- Parsed changed workflow YAML with `yq e '.'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-cli/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->