### PR TITLE
[codex] print validator count to stdout

### DIFF
--- a/src/commands/localnet/validators.ts
+++ b/src/commands/localnet/validators.ts
@@ -89,6 +89,7 @@ export class ValidatorsAction extends BaseAction {
         method: "sim_countValidators",
         params: [],
       });
+      console.log(`Total Validators: ${result.result}`);
       this.succeedSpinner(`Total Validators: ${result.result}`);
     } catch (error) {
       this.failSpinner("Error counting validators", error);
@@ -265,5 +266,4 @@ export class ValidatorsAction extends BaseAction {
     }
   }
 }
-
 


### PR DESCRIPTION
## Summary

- print `localnet validators count` results to stdout
- keep the existing spinner success message

## Why

The Studio tooling E2E expects a parseable validator count. The CLI previously only surfaced the count through spinner output, which can be blank or suppressed in CI.

## Validation

- npm test -- tests/actions/validators.test.ts
- focused Studio CLI validator count E2E locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced console output for validator count reporting in localnet operations.
  * Code formatting improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-cli/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->