### PR TITLE
fix(system): handle ENOENT in checkCommand and throw on unmatched version in getVersion

### DIFF
--- a/src/lib/clients/system.ts
+++ b/src/lib/clients/system.ts
@@ -9,7 +9,7 @@ export async function checkCommand(command: string, toolName: string): Promise<v
   try {
     await util.promisify(exec)(command);
   }catch (error:any) {
-    if (error.stderr) {
+    if (error.code === 'ENOENT' || error.stderr) {
       throw new MissingRequirementError(toolName);
     }
   }
@@ -50,24 +50,28 @@ export function openUrl(url: string): Promise<ChildProcess> {
 }
 
 export async function getVersion(toolName: string): Promise<string> {
+  let toolResponse: {stdout?: string; stderr?: string};
+
   try {
-    const toolResponse = await util.promisify(exec)(`${toolName} --version`);
-
-    if (toolResponse.stderr) {
-      throw new Error(toolResponse.stderr);
-    }
-
-    try {
-      const versionMatch = toolResponse.stdout.match(/(\d+\.\d+\.\d+)/);
-      if (versionMatch) {
-        return versionMatch[1];
-      }
-    } catch (err) {
-      throw new Error(`Could not parse ${toolName} version.`);
-    }
+    toolResponse = await util.promisify(exec)(`${toolName} --version`);
   } catch (error) {
     throw new Error(`Error getting ${toolName} version.`);
   }
 
-  return "";
+  if (toolResponse.stderr) {
+    throw new Error(`Error getting ${toolName} version.`);
+  }
+
+  if (toolResponse.stdout == null) {
+    throw new Error(`Error getting ${toolName} version.`);
+  }
+
+  const versionMatch = toolResponse.stdout.match(/(\d+\.\d+\.\d+)/);
+  if (versionMatch) {
+    return versionMatch[1];
+  }
+
+  throw new Error(
+    `Could not parse ${toolName} version from output: "${toolResponse.stdout}". Expected format: X.Y.Z`
+  );
 }

--- a/tests/libs/system.test.ts
+++ b/tests/libs/system.test.ts
@@ -70,13 +70,15 @@ describe("System Functions - Error Paths", () => {
     await expect(getVersion(toolName)).rejects.toThrow(`Error getting ${toolName} version.`);
   });
 
-  test("getVersion returns '' if stdout is empty", async () => {
+  test("getVersion throws when stdout does not match version pattern", async () => {
     vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.resolve({
       stdout: "",
       stderr: ""
     }));
-    const result = await getVersion('git');
-    expect(result).toBe("");
+    const toolName = "git";
+    await expect(getVersion(toolName)).rejects.toThrow(
+      `Could not parse ${toolName} version from output`
+    );
   });
 
   test("getVersion throw error if stdout undefined", async () => {
@@ -87,12 +89,33 @@ describe("System Functions - Error Paths", () => {
     await expect(getVersion(toolName)).rejects.toThrow(`Error getting ${toolName} version.`);
   });
 
+  test("getVersion throws when stdout has non-matching version format (e.g. major-only)", async () => {
+    vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.resolve({
+      stdout: "Docker version 25",
+      stderr: ""
+    }));
+    const toolName = "docker";
+    await expect(getVersion(toolName)).rejects.toThrow(
+      `Could not parse ${toolName} version from output`
+    );
+  });
+
   test("checkCommand returns false if the command does not exist", async () => {
     vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.reject({
       stdout: "",
       stderr: "command not found"
     }));
     const toolName = 'nonexistent';
+    await expect(checkCommand(`${toolName} --version`, toolName)).rejects.toThrow(new MissingRequirementError(toolName));
+  });
+
+  test("checkCommand throws MissingRequirementError when binary is not installed (ENOENT)", async () => {
+    vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.reject({
+      code: 'ENOENT',
+      stderr: '',
+      message: 'spawn ENOENT'
+    }));
+    const toolName = 'docker';
     await expect(checkCommand(`${toolName} --version`, toolName)).rejects.toThrow(new MissingRequirementError(toolName));
   });
 


### PR DESCRIPTION
Fixes #301 and #303.

**Bug #301 — checkCommand false positive**
When a required binary is not installed, child_process.exec 
rejects with error.code === 'ENOENT' and empty stderr. The 
previous guard `if (error.stderr)` evaluated to false, 
swallowing the error and reporting the tool as present.

Fixed by adding error.code === 'ENOENT' to the condition.

**Bug #303 — getVersion silent empty string**
When the version regex didn't match (e.g. stdout was 
"Docker version 25" with no X.Y.Z pattern), the function 
fell through the dead inner try/catch and returned "". 
The caller then ran semver.satisfies("", ">=X.Y.Z") → false, 
producing a misleading "please update" error when the tool 
was already the correct version.

Fixed by removing the dead try/catch and throwing explicitly 
when the regex produces no match. The unreachable return "" 
is also removed.

**Tests**
- Updated existing test that encoded the buggy "" return 
  as correct behavior
- Added ENOENT test case for checkCommand
- Added non-matching stdout test case for getVersion

506 tests passing, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and error handling for missing system tools
  * Enhanced error messages when tool version information cannot be retrieved or parsed

* **Tests**
  * Expanded test coverage for error scenarios involving missing tools and invalid version formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-cli/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->