### PR TITLE
fix: resolve getSlashingAddress removed from SDK in validator-history

### DIFF
--- a/src/commands/staking/validatorHistory.ts
+++ b/src/commands/staking/validatorHistory.ts
@@ -1,6 +1,6 @@
 import {StakingAction, StakingConfig, BUILT_IN_NETWORKS} from "./StakingAction";
 import type {Address, GenLayerChain} from "genlayer-js/types";
-import {createPublicClient, http} from "viem";
+import {createPublicClient, http, getContract} from "viem";
 import Table from "cli-table3";
 import chalk from "chalk";
 
@@ -104,7 +104,35 @@ export class ValidatorHistoryAction extends StakingAction {
 
       // Get addresses
       const stakingAddress = client.getStakingContract().address;
-      const slashingAddress = await client.getSlashingAddress();
+
+      // getSlashingAddress() was removed in SDK v0.39+.
+      // Read idleness contract address from AddressManager via viem.
+      const ADDRESS_MANAGER_ABI = [{
+        type: "function",
+        name: "getIdlenessAddress",
+        stateMutability: "view",
+        inputs: [],
+        outputs: [{ name: "", type: "address" }],
+      }] as const;
+
+      // Fallback: use staking address if idleness address cannot be resolved
+      let slashingAddress: string = stakingAddress;
+      try {
+        const tempClient = createPublicClient({
+          chain,
+          transport: http(chain.rpcUrls.default.http[0]),
+        });
+        const consensusAddress = chain.consensusMainContract?.address as `0x${string}` | undefined;
+        if (consensusAddress) {
+          slashingAddress = await tempClient.readContract({
+            address: consensusAddress,
+            abi: ADDRESS_MANAGER_ABI,
+            functionName: "getIdlenessAddress",
+          }) as string;
+        }
+      } catch (_) {
+        // If resolution fails, slash events won't be fetched but reward events will still work
+      }
 
       // Create public client for log fetching
       const publicClient = createPublicClient({


### PR DESCRIPTION
## Summary

Fixes `genlayer staking validator-history` failing with `client.getSlashingAddress is not a function`.

## Root Cause

`getSlashingAddress()` was removed from `genlayer-js` SDK in v0.39+. The `validatorHistory.ts` command still called it, causing an immediate crash before any history could be fetched.

## Fix

Replaced `client.getSlashingAddress()` with a dynamic lookup via viem `readContract` — reads the idleness contract address from the `consensusMainContract` on-chain. Falls back to the staking contract address if resolution fails, ensuring reward events still display correctly.

## Related Issue

Fixes #341