### PR TITLE
fix: fail CLI writes on execution errors

### DIFF
--- a/src/commands/contracts/deploy.ts
+++ b/src/commands/contracts/deploy.ts
@@ -5,6 +5,7 @@ import {pathToFileURL} from "url";
 import {TransactionStatus} from "genlayer-js/types";
 import {buildSync} from "esbuild";
 import {ContractFeeCliOptions, parseTransactionFees, parseValidUntil} from "./fees";
+import {assertSuccessfulExecution} from "./execution";
 
 export interface DeployOptions extends ContractFeeCliOptions {
   contract?: string;
@@ -147,7 +148,9 @@ export class DeployAction extends BaseAction {
         retries: 50,
         interval: 5000,
         status: TransactionStatus.ACCEPTED,
+        fullTransaction: true,
       });
+      assertSuccessfulExecution("Deployment", hash, result);
 
       this.log("Deployment Receipt:", result);
 

--- a/src/commands/contracts/execution.ts
+++ b/src/commands/contracts/execution.ts
@@ -1,0 +1,75 @@
+import {ExecutionResult} from "genlayer-js/types";
+
+function directField(value: unknown, names: string[]): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  for (const name of names) {
+    if (Object.prototype.hasOwnProperty.call(record, name)) return record[name];
+  }
+  return undefined;
+}
+
+function normalizeExecutionResult(value: unknown): ExecutionResult | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "string") {
+    const normalized = value.toUpperCase();
+    if (normalized === ExecutionResult.FINISHED_WITH_RETURN) return ExecutionResult.FINISHED_WITH_RETURN;
+    if (normalized === ExecutionResult.FINISHED_WITH_ERROR) return ExecutionResult.FINISHED_WITH_ERROR;
+    if (normalized === ExecutionResult.NOT_VOTED) return ExecutionResult.NOT_VOTED;
+    if (normalized === "SUCCESS") return ExecutionResult.FINISHED_WITH_RETURN;
+    if (normalized === "ERROR" || normalized === "FAILURE") return ExecutionResult.FINISHED_WITH_ERROR;
+    if (/^\d+$/.test(normalized)) return normalizeExecutionResult(Number(normalized));
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    const numeric = Number(value);
+    if (numeric === 0) return ExecutionResult.NOT_VOTED;
+    if (numeric === 1) return ExecutionResult.FINISHED_WITH_RETURN;
+    if (numeric === 2) return ExecutionResult.FINISHED_WITH_ERROR;
+  }
+  return undefined;
+}
+
+function transactionExecutionResult(receipt: unknown): ExecutionResult | undefined {
+  const record = receipt && typeof receipt === "object" && !Array.isArray(receipt)
+    ? receipt as Record<string, unknown>
+    : {};
+  const data = directField(record, ["data"]);
+  const consensusData =
+    directField(data, ["consensus_data", "consensusData"]) ??
+    directField(record, ["consensus_data", "consensusData"]);
+  const leaderReceipt = directField(consensusData, ["leader_receipt", "leaderReceipt"]);
+  const firstLeaderReceipt = Array.isArray(leaderReceipt) ? leaderReceipt[0] : leaderReceipt;
+  const genvmResult = directField(firstLeaderReceipt, ["genvm_result", "genvmResult"]);
+
+  const candidates = [
+    directField(record, ["txExecutionResultName", "tx_execution_result_name"]),
+    directField(record, ["txExecutionResult", "tx_execution_result"]),
+    directField(data, ["txExecutionResultName", "tx_execution_result_name"]),
+    directField(data, ["txExecutionResult", "tx_execution_result"]),
+    directField(firstLeaderReceipt, ["execution_result", "executionResult"]),
+    directField(genvmResult, ["execution_result", "executionResult"]),
+    directField(data, ["execution_result", "executionResult"]),
+  ];
+  for (const candidate of candidates) {
+    const result = normalizeExecutionResult(candidate);
+    if (result !== undefined) return result;
+  }
+  return undefined;
+}
+
+export function assertSuccessfulExecution(
+  operation: string,
+  hash: unknown,
+  receipt: unknown,
+): void {
+  const result = transactionExecutionResult(receipt);
+  if (result === ExecutionResult.FINISHED_WITH_RETURN) return;
+
+  if (result === undefined) {
+    throw new Error(
+      `${operation} ${String(hash)} reached consensus status but did not expose an execution result.`,
+    );
+  }
+
+  throw new Error(`${operation} ${String(hash)} execution failed with ${result}.`);
+}

--- a/src/commands/contracts/write.ts
+++ b/src/commands/contracts/write.ts
@@ -2,6 +2,7 @@
 // import type {GenLayerClient} from "genlayer-js/types";
 import {BaseAction} from "../../lib/actions/BaseAction";
 import {ContractFeeCliOptions, parseTransactionFees, parseValidUntil} from "./fees";
+import {assertSuccessfulExecution} from "./execution";
 
 export interface WriteOptions extends ContractFeeCliOptions {
   args: any[];
@@ -53,7 +54,9 @@ export class WriteAction extends BaseAction {
         hash,
         retries: 100,
         interval: 5000,
+        fullTransaction: true,
       });
+      assertSuccessfulExecution("Write", hash, result);
       this.succeedSpinner("Write operation successfully executed", result);
     } catch (error) {
       this.failSpinner("Error during write operation", error);

--- a/tests/actions/deploy.test.ts
+++ b/tests/actions/deploy.test.ts
@@ -81,6 +81,7 @@ describe("DeployAction", () => {
     vi.mocked(fs.readFileSync).mockReturnValue(contractContent);
     vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      txExecutionResultName: "FINISHED_WITH_RETURN",
       data: {contract_address: "0xdasdsadasdasdada"},
     });
 
@@ -91,6 +92,13 @@ describe("DeployAction", () => {
       code: contractContent,
       args: [1, 2, 3],
       leaderOnly: false,
+    });
+    expect(mockClient.waitForTransactionReceipt).toHaveBeenCalledWith({
+      hash: "mocked_tx_hash",
+      retries: 50,
+      interval: 5000,
+      status: "ACCEPTED",
+      fullTransaction: true,
     });
     expect(mockClient.deployContract).toHaveReturnedWith(Promise.resolve("mocked_tx_hash"));
   });
@@ -119,6 +127,7 @@ describe("DeployAction", () => {
     vi.mocked(fs.readFileSync).mockReturnValue(contractContent);
     vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      txExecutionResultName: "FINISHED_WITH_RETURN",
       data: {contract_address: "0xdasdsadasdasdada"},
     });
 
@@ -142,6 +151,30 @@ describe("DeployAction", () => {
       },
       validUntil: "999",
     });
+  });
+
+  test("fails when deployment reaches consensus but execution fails", async () => {
+    const options: DeployOptions = {
+      contract: "/mocked/contract/path",
+      args: [1, 2, 3],
+    };
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue("contract code");
+    vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      txExecutionResultName: "FINISHED_WITH_ERROR",
+      data: {contract_address: "0xdasdsadasdasdada"},
+    });
+
+    await deployer.deploy(options);
+
+    expect(deployer["failSpinner"]).toHaveBeenCalledWith(
+      "Error deploying contract",
+      expect.objectContaining({
+        message: expect.stringContaining("execution failed with FINISHED_WITH_ERROR"),
+      }),
+    );
   });
 
   test("throws error for missing contract", async () => {
@@ -387,6 +420,7 @@ describe("DeployAction", () => {
     vi.mocked(fs.readFileSync).mockReturnValue(contractContent);
     vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      txExecutionResultName: "FINISHED_WITH_RETURN",
       data: {contract_address: "0xdasdsadasdasdada"},
     });
 

--- a/tests/actions/write.test.ts
+++ b/tests/actions/write.test.ts
@@ -34,7 +34,7 @@ describe("WriteAction", () => {
   test("calls writeContract successfully", async () => {
     const options = {args: [42, "Update"]};
     const mockHash = "0xMockedTransactionHash";
-    const mockReceipt = {status: "success"};
+    const mockReceipt = {status: "success", txExecutionResultName: "FINISHED_WITH_RETURN"};
 
     vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue(mockReceipt);
@@ -52,6 +52,12 @@ describe("WriteAction", () => {
       value: 0n,
     });
     expect(writeAction["log"]).toHaveBeenCalledWith("Write Transaction Hash:", mockHash);
+    expect(mockClient.waitForTransactionReceipt).toHaveBeenCalledWith({
+      hash: mockHash,
+      retries: 100,
+      interval: 5000,
+      fullTransaction: true,
+    });
     expect(writeAction["succeedSpinner"]).toHaveBeenCalledWith(
       "Write operation successfully executed",
       mockReceipt,
@@ -60,7 +66,7 @@ describe("WriteAction", () => {
 
   test("calls writeContract with fee options", async () => {
     const mockHash = "0xMockedTransactionHash";
-    const mockReceipt = {status: "success"};
+    const mockReceipt = {status: "success", txExecutionResultName: "FINISHED_WITH_RETURN"};
 
     vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue(mockReceipt);
@@ -116,10 +122,29 @@ describe("WriteAction", () => {
     );
   });
 
+  test("fails when write reaches consensus but execution fails", async () => {
+    const mockHash = "0xMockedTransactionHash";
+
+    vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      status: "success",
+      txExecutionResultName: "FINISHED_WITH_ERROR",
+    });
+
+    await writeAction.write({contractAddress: "0xMockedContract", method: "updateData", args: [1]});
+
+    expect(writeAction["failSpinner"]).toHaveBeenCalledWith(
+      "Error during write operation",
+      expect.objectContaining({
+        message: expect.stringContaining("execution failed with FINISHED_WITH_ERROR"),
+      }),
+    );
+  });
+
   test("uses custom RPC URL for write operations", async () => {
     const options = {args: [42, "Update"], rpc: "https://custom-rpc-url.com"};
     const mockHash = "0xMockedTransactionHash";
-    const mockReceipt = {status: "success"};
+    const mockReceipt = {status: "success", txExecutionResultName: "FINISHED_WITH_RETURN"};
 
     vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue(mockReceipt);


### PR DESCRIPTION
## Summary
- request full transaction receipts for deploy/write waits
- fail deploy/write commands when consensus accepts a tx but GenVM execution fails
- add focused deploy/write action tests for execution result handling

## Validation
- npm test -- tests/actions/deploy.test.ts tests/actions/write.test.ts

Known train status: full v0.6 E2E is still expected to be red on the consensus validatorPrime/AlreadyClaimed blocker.