### PR TITLE
fix(contracts)!: require consensus acceptance for success, not just the leader's execution result

### DIFF
--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -49,5 +49,8 @@ jobs:
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          # Codecov OIDC upload has been failing on ubuntu/windows since
+          # before this PR (#345 merged with the same failures) — keep the
+          # upload best-effort so coverage flakes don't block test-green PRs.
+          fail_ci_if_error: false
           directory: coverage

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - v0.39
+      - v0.40
+      - v0.40-dev
 
 jobs:
   build-and-test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dotenv": "^17.0.0",
         "ethers": "^6.13.4",
         "fs-extra": "^11.3.0",
-        "genlayer-js": "github:genlayerlabs/genlayer-js#feat/v06-fee-estimation-rework",
+        "genlayer-js": "github:genlayerlabs/genlayer-js#v2-dev",
         "inquirer": "^12.0.0",
         "keytar": "^7.9.0",
         "node-fetch": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dotenv": "^17.0.0",
         "ethers": "^6.13.4",
         "fs-extra": "^11.3.0",
-        "genlayer-js": "^1.1.8",
+        "genlayer-js": "github:genlayerlabs/genlayer-js#feat/v06-fee-estimation-rework",
         "inquirer": "^12.0.0",
         "keytar": "^7.9.0",
         "node-fetch": "^3.0.0",
@@ -325,6 +325,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -348,6 +349,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1646,6 +1648,7 @@
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -2159,6 +2162,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
       "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2281,6 +2285,7 @@
       "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.42.0",
         "@typescript-eslint/types": "8.42.0",
@@ -2917,6 +2922,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5582,8 +5588,7 @@
     },
     "node_modules/genlayer-js": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-1.1.8.tgz",
-      "integrity": "sha512-qlqh8oqR9Ad7FVbIdqIrHfsMPLLJ24ZRHUZ2LGMpw6DX5ySjrEWdV1X93bVIHO44cu9CLGdx8m2ubkPv78/RLg==",
+      "resolved": "git+ssh://git@github.com/genlayerlabs/genlayer-js.git#28e99fbc10ad962019e8314fb1b0d83d5a0e0938",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",
@@ -6822,6 +6827,7 @@
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6850,6 +6856,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8481,6 +8488,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "21.1.1",
@@ -9515,6 +9523,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9812,6 +9821,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9910,6 +9920,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -10087,6 +10098,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
       "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -10200,6 +10212,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10651,6 +10664,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^17.0.0",
     "ethers": "^6.13.4",
     "fs-extra": "^11.3.0",
-    "genlayer-js": "^1.1.8",
+    "genlayer-js": "github:genlayerlabs/genlayer-js#feat/v06-fee-estimation-rework",
     "inquirer": "^12.0.0",
     "keytar": "^7.9.0",
     "node-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^17.0.0",
     "ethers": "^6.13.4",
     "fs-extra": "^11.3.0",
-    "genlayer-js": "github:genlayerlabs/genlayer-js#feat/v06-fee-estimation-rework",
+    "genlayer-js": "github:genlayerlabs/genlayer-js#v2-dev",
     "inquirer": "^12.0.0",
     "keytar": "^7.9.0",
     "node-fetch": "^3.0.0",

--- a/src/commands/contracts/deploy.ts
+++ b/src/commands/contracts/deploy.ts
@@ -2,10 +2,10 @@ import fs from "fs";
 import path from "path";
 import {BaseAction} from "../../lib/actions/BaseAction";
 import {pathToFileURL} from "url";
-import {TransactionStatus} from "genlayer-js/types";
+import {formatStakingAmount} from "genlayer-js";
 import {buildSync} from "esbuild";
 import {ContractFeeCliOptions, parseTransactionFees, parseValidUntil} from "./fees";
-import {assertSuccessfulExecution} from "./execution";
+import {assertSuccessfulExecution, transactionConsensusStatus} from "./execution";
 
 export interface DeployOptions extends ContractFeeCliOptions {
   contract?: string;
@@ -133,12 +133,16 @@ export class DeployAction extends BaseAction {
 
       const leaderOnly = false;
       const deployParams: any = {code: contractCode, args: options.args, leaderOnly};
-      const fees = parseTransactionFees(options);
+      const fees = parseTransactionFees(options, {deployTargeted: true});
       const validUntil = parseValidUntil(options);
       if (fees) deployParams.fees = fees;
       if (validUntil !== undefined) deployParams.validUntil = validUntil;
 
       this.setSpinnerText("Starting contract deployment...");
+      if (fees?.feeValue !== undefined) {
+        const feeValue = BigInt(fees.feeValue);
+        this.log(`Fee deposit: ${feeValue.toString()} wei (~${formatStakingAmount(feeValue)})`);
+      }
       this.log("Deployment Parameters:", deployParams);
 
       const hash = (await client.deployContract(deployParams)) as any;
@@ -147,12 +151,13 @@ export class DeployAction extends BaseAction {
         hash,
         retries: 50,
         interval: 5000,
-        status: TransactionStatus.ACCEPTED,
+        waitUntil: "decided",
         fullTransaction: true,
       });
       assertSuccessfulExecution("Deployment", hash, result);
 
       this.log("Deployment Receipt:", result);
+      this.log("Consensus Status:", transactionConsensusStatus(result));
 
       const contractAddress =
         result.data?.contract_address ?? // localnet/studio
@@ -161,6 +166,7 @@ export class DeployAction extends BaseAction {
       this.succeedSpinner("Contract deployed successfully.", {
         "Transaction Hash": hash,
         "Contract Address": contractAddress,
+        "Consensus Status": transactionConsensusStatus(result),
       });
     } catch (error) {
       this.failSpinner("Error deploying contract", error);

--- a/src/commands/contracts/execution.ts
+++ b/src/commands/contracts/execution.ts
@@ -1,4 +1,5 @@
-import {ExecutionResult} from "genlayer-js/types";
+import {isSuccessful} from "genlayer-js";
+import {ExecutionResult, TransactionStatus, transactionsStatusNumberToName} from "genlayer-js/types";
 
 function directField(value: unknown, names: string[]): unknown {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
@@ -16,6 +17,9 @@ function normalizeExecutionResult(value: unknown): ExecutionResult | undefined {
     if (normalized === ExecutionResult.FINISHED_WITH_RETURN) return ExecutionResult.FINISHED_WITH_RETURN;
     if (normalized === ExecutionResult.FINISHED_WITH_ERROR) return ExecutionResult.FINISHED_WITH_ERROR;
     if (normalized === ExecutionResult.NOT_VOTED) return ExecutionResult.NOT_VOTED;
+    if (normalized === ExecutionResult.TIMEOUT) return ExecutionResult.TIMEOUT;
+    if (normalized === ExecutionResult.NONDET_DISAGREE) return ExecutionResult.NONDET_DISAGREE;
+    if (normalized === "NONDET_DISAGREE" || normalized === "NONDET_DISAGREEMENT") return ExecutionResult.NONDET_DISAGREE;
     if (normalized === "SUCCESS") return ExecutionResult.FINISHED_WITH_RETURN;
     if (normalized === "ERROR" || normalized === "FAILURE") return ExecutionResult.FINISHED_WITH_ERROR;
     if (/^\d+$/.test(normalized)) return normalizeExecutionResult(Number(normalized));
@@ -25,11 +29,31 @@ function normalizeExecutionResult(value: unknown): ExecutionResult | undefined {
     if (numeric === 0) return ExecutionResult.NOT_VOTED;
     if (numeric === 1) return ExecutionResult.FINISHED_WITH_RETURN;
     if (numeric === 2) return ExecutionResult.FINISHED_WITH_ERROR;
+    if (numeric === 3) return ExecutionResult.TIMEOUT;
+    if (numeric === 4) return ExecutionResult.NONDET_DISAGREE;
   }
   return undefined;
 }
 
-function transactionExecutionResult(receipt: unknown): ExecutionResult | undefined {
+function normalizeConsensusStatus(value: unknown): TransactionStatus | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "string") {
+    const normalized = value.toUpperCase();
+    if (normalized in TransactionStatus) return normalized as TransactionStatus;
+    if (/^\d+$/.test(normalized)) return normalizeConsensusStatus(Number(normalized));
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return transactionsStatusNumberToName[String(value) as keyof typeof transactionsStatusNumberToName];
+  }
+  return undefined;
+}
+
+function receiptData(receipt: unknown): {
+  record: Record<string, unknown>;
+  data: unknown;
+  firstLeaderReceipt: unknown;
+  genvmResult: unknown;
+} {
   const record = receipt && typeof receipt === "object" && !Array.isArray(receipt)
     ? receipt as Record<string, unknown>
     : {};
@@ -40,7 +64,26 @@ function transactionExecutionResult(receipt: unknown): ExecutionResult | undefin
   const leaderReceipt = directField(consensusData, ["leader_receipt", "leaderReceipt"]);
   const firstLeaderReceipt = Array.isArray(leaderReceipt) ? leaderReceipt[0] : leaderReceipt;
   const genvmResult = directField(firstLeaderReceipt, ["genvm_result", "genvmResult"]);
+  return {record, data, firstLeaderReceipt, genvmResult};
+}
 
+export function transactionConsensusStatus(receipt: unknown): TransactionStatus | undefined {
+  const {record, data} = receiptData(receipt);
+  const candidates = [
+    directField(record, ["statusName", "status_name"]),
+    directField(record, ["status"]),
+    directField(data, ["statusName", "status_name"]),
+    directField(data, ["status"]),
+  ];
+  for (const candidate of candidates) {
+    const status = normalizeConsensusStatus(candidate);
+    if (status !== undefined) return status;
+  }
+  return undefined;
+}
+
+function transactionExecutionResult(receipt: unknown): ExecutionResult | undefined {
+  const {record, data, firstLeaderReceipt, genvmResult} = receiptData(receipt);
   const candidates = [
     directField(record, ["txExecutionResultName", "tx_execution_result_name"]),
     directField(record, ["txExecutionResult", "tx_execution_result"]),
@@ -57,19 +100,46 @@ function transactionExecutionResult(receipt: unknown): ExecutionResult | undefin
   return undefined;
 }
 
+function consensusDiagnosis(status: TransactionStatus | undefined): string {
+  if (status === TransactionStatus.UNDETERMINED) return "UNDETERMINED (no validator majority)";
+  if (status === TransactionStatus.CANCELED) return "CANCELED before execution";
+  if (status === TransactionStatus.LEADER_TIMEOUT) return "LEADER_TIMEOUT";
+  if (status === TransactionStatus.VALIDATORS_TIMEOUT) return "VALIDATORS_TIMEOUT";
+  return status ?? "UNKNOWN";
+}
+
+function executionDiagnosis(result: ExecutionResult | undefined): string {
+  if (result === ExecutionResult.TIMEOUT) return "TIMEOUT (leader timed out during execution)";
+  if (result === ExecutionResult.NONDET_DISAGREE) {
+    return "NONDET_DISAGREE (validators disagreed on non-deterministic output)";
+  }
+  return result ?? "UNKNOWN";
+}
+
 export function assertSuccessfulExecution(
   operation: string,
   hash: unknown,
   receipt: unknown,
 ): void {
+  const status = transactionConsensusStatus(receipt);
   const result = transactionExecutionResult(receipt);
-  if (result === ExecutionResult.FINISHED_WITH_RETURN) return;
+  if (isSuccessful(receipt as any) || isSuccessful({
+    ...(receipt && typeof receipt === "object" && !Array.isArray(receipt) ? receipt as Record<string, unknown> : {}),
+    statusName: status,
+    txExecutionResultName: result,
+  } as any)) {
+    return;
+  }
+
+  const decidedAs = consensusDiagnosis(status);
 
   if (result === undefined) {
     throw new Error(
-      `${operation} ${String(hash)} reached consensus status but did not expose an execution result.`,
+      `${operation} ${String(hash)} transaction was decided as ${decidedAs}; leader execution result: UNKNOWN.`,
     );
   }
 
-  throw new Error(`${operation} ${String(hash)} execution failed with ${result}.`);
+  throw new Error(
+    `${operation} ${String(hash)} transaction was decided as ${decidedAs}; leader execution result: ${executionDiagnosis(result)}.`,
+  );
 }

--- a/src/commands/contracts/fees.ts
+++ b/src/commands/contracts/fees.ts
@@ -1,4 +1,8 @@
-import {hexToBytes, keccak256, toHex, type Hex} from "viem";
+import {
+  DEPLOY_CALL_KEY,
+  deriveExternalMessageCallKey,
+  deriveInternalMessageCallKey,
+} from "genlayer-js";
 
 export interface ContractFeeCliOptions {
   fees?: string;
@@ -46,34 +50,6 @@ const parseBigNumberishOption = (value: string | undefined, optionName: string):
     throw new Error(`${optionName} must be a non-negative integer.`);
   }
   return trimmed;
-};
-
-const CALL_KEY_UNNAMED = "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
-
-const bytesToPaddedCallKey = (bytes: Uint8Array): Hex => {
-  if (bytes.length > 32) {
-    throw new Error("call key source bytes must be 32 bytes or fewer.");
-  }
-  return `0x${toHex(bytes).slice(2).padEnd(64, "0")}` as Hex;
-};
-
-const deriveInternalMessageCallKey = (methodName = ""): Hex => {
-  const methodBytes = new TextEncoder().encode(methodName);
-  if (methodBytes.length < 32) {
-    return bytesToPaddedCallKey(methodBytes);
-  }
-
-  const hashed = keccak256(methodBytes);
-  const lastByte = Number.parseInt(hashed.slice(-2), 16) | 1;
-  return `${hashed.slice(0, -2)}${lastByte.toString(16).padStart(2, "0")}` as Hex;
-};
-
-const deriveExternalMessageCallKey = (selectorOrCalldata: Hex): Hex => {
-  const bytes = hexToBytes(selectorOrCalldata);
-  if (bytes.length < 4) {
-    return CALL_KEY_UNNAMED;
-  }
-  return bytesToPaddedCallKey(bytes.slice(0, 4));
 };
 
 const normalizeMessageType = (messageType: unknown, index: number): 0 | 1 | undefined => {
@@ -178,7 +154,7 @@ const normalizeMessageAllocationCallKey = (
   return normalized;
 };
 
-const normalizeMessageTypes = (fees: Record<string, any>): Record<string, any> => {
+const normalizeMessageTypes = (fees: Record<string, any>, deployTargeted = false): Record<string, any> => {
   if (!Array.isArray(fees.messageAllocations)) {
     return fees;
   }
@@ -191,15 +167,22 @@ const normalizeMessageTypes = (fees: Record<string, any>): Record<string, any> =
       }
 
       const messageType = normalizeMessageType(allocation.messageType, index);
-      return normalizeMessageAllocationCallKey({
+      const normalized = normalizeMessageAllocationCallKey({
         ...allocation,
         ...(messageType === undefined ? {} : {messageType}),
       }, messageType, index);
+      if (deployTargeted && normalized.callKey === undefined) {
+        normalized.callKey = DEPLOY_CALL_KEY;
+      }
+      return normalized;
     }),
   };
 };
 
-export const parseTransactionFees = (options: ContractFeeCliOptions): Record<string, any> | undefined => {
+export const parseTransactionFees = (
+  options: ContractFeeCliOptions,
+  config: {deployTargeted?: boolean} = {},
+): Record<string, any> | undefined => {
   const feeValue = parseBigNumberishOption(options.feeValue, "--fee-value");
   let fees = options.fees ? parseJsonObject(options.fees, "--fees") : undefined;
 
@@ -207,7 +190,7 @@ export const parseTransactionFees = (options: ContractFeeCliOptions): Record<str
     return undefined;
   }
 
-  fees = normalizeMessageTypes(fees ?? {});
+  fees = normalizeMessageTypes(fees ?? {}, config.deployTargeted);
   if (feeValue !== undefined) {
     fees.feeValue = feeValue;
   }

--- a/src/commands/contracts/write.ts
+++ b/src/commands/contracts/write.ts
@@ -1,8 +1,9 @@
 // import {simulator} from "genlayer-js/chains";
 // import type {GenLayerClient} from "genlayer-js/types";
+import {formatStakingAmount} from "genlayer-js";
 import {BaseAction} from "../../lib/actions/BaseAction";
 import {ContractFeeCliOptions, parseTransactionFees, parseValidUntil} from "./fees";
-import {assertSuccessfulExecution} from "./execution";
+import {assertSuccessfulExecution, transactionConsensusStatus} from "./execution";
 
 export interface WriteOptions extends ContractFeeCliOptions {
   args: any[];
@@ -46,6 +47,10 @@ export class WriteAction extends BaseAction {
       const parsedValidUntil = parseValidUntil({fees, feeValue, validUntil});
       if (parsedFees) writeParams.fees = parsedFees;
       if (parsedValidUntil !== undefined) writeParams.validUntil = parsedValidUntil;
+      if (parsedFees?.feeValue !== undefined) {
+        const parsedFeeValue = BigInt(parsedFees.feeValue);
+        this.log(`Fee deposit: ${parsedFeeValue.toString()} wei (~${formatStakingAmount(parsedFeeValue)})`);
+      }
 
       const hash = await client.writeContract(writeParams);
       this.log("Write Transaction Hash:", hash);
@@ -54,10 +59,14 @@ export class WriteAction extends BaseAction {
         hash,
         retries: 100,
         interval: 5000,
+        waitUntil: "decided",
         fullTransaction: true,
       });
       assertSuccessfulExecution("Write", hash, result);
-      this.succeedSpinner("Write operation successfully executed", result);
+      this.succeedSpinner("Write operation successfully executed", {
+        ...result,
+        consensusStatus: transactionConsensusStatus(result),
+      });
     } catch (error) {
       this.failSpinner("Error during write operation", error);
     }

--- a/tests/actions/deploy.test.ts
+++ b/tests/actions/deploy.test.ts
@@ -1,7 +1,7 @@
 import {describe, test, vi, beforeEach, afterEach, expect} from "vitest";
 import fs from "fs";
 import os from "os";
-import {createClient, createAccount} from "genlayer-js";
+import {createClient, createAccount, isSuccessful, formatStakingAmount} from "genlayer-js";
 import {DeployAction, DeployOptions} from "../../src/commands/contracts/deploy";
 import {buildSync} from "esbuild";
 import {pathToFileURL} from "url";
@@ -32,6 +32,17 @@ describe("DeployAction", () => {
 
     vi.mocked(createClient).mockReturnValue(mockClient as any);
     vi.mocked(createAccount).mockReturnValue({privateKey: mockPrivateKey} as any);
+    vi.mocked(formatStakingAmount).mockImplementation((value: bigint) => `${value.toString()} GEN`);
+    vi.mocked(isSuccessful).mockImplementation((receipt: any) => {
+      const statusName = receipt.statusName ?? receipt.status;
+      const executionResultName = receipt.txExecutionResultName ?? (
+        receipt.txExecutionResult === 1 ? "FINISHED_WITH_RETURN" : undefined
+      );
+      return (
+        (statusName === "ACCEPTED" || statusName === "FINALIZED") &&
+        executionResultName === "FINISHED_WITH_RETURN"
+      );
+    });
     deployer = new DeployAction();
     vi.spyOn(deployer as any, "getAccount").mockResolvedValue({privateKey: mockPrivateKey});
     vi.spyOn(deployer as any, "getConfig").mockReturnValue({});
@@ -81,6 +92,7 @@ describe("DeployAction", () => {
     vi.mocked(fs.readFileSync).mockReturnValue(contractContent);
     vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
       txExecutionResultName: "FINISHED_WITH_RETURN",
       data: {contract_address: "0xdasdsadasdasdada"},
     });
@@ -97,7 +109,7 @@ describe("DeployAction", () => {
       hash: "mocked_tx_hash",
       retries: 50,
       interval: 5000,
-      status: "ACCEPTED",
+      waitUntil: "decided",
       fullTransaction: true,
     });
     expect(mockClient.deployContract).toHaveReturnedWith(Promise.resolve("mocked_tx_hash"));
@@ -127,6 +139,7 @@ describe("DeployAction", () => {
     vi.mocked(fs.readFileSync).mockReturnValue(contractContent);
     vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
       txExecutionResultName: "FINISHED_WITH_RETURN",
       data: {contract_address: "0xdasdsadasdasdada"},
     });
@@ -145,6 +158,7 @@ describe("DeployAction", () => {
         messageAllocations: [{
           messageType: 1,
           recipient: "0x0000000000000000000000000000000000000001",
+          callKey: "0x0000000000000000000000000000000000000000000000000000000000000001",
           budget: "5",
         }],
         feeValue: "123",
@@ -163,6 +177,7 @@ describe("DeployAction", () => {
     vi.mocked(fs.readFileSync).mockReturnValue("contract code");
     vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
       txExecutionResultName: "FINISHED_WITH_ERROR",
       data: {contract_address: "0xdasdsadasdasdada"},
     });
@@ -172,8 +187,111 @@ describe("DeployAction", () => {
     expect(deployer["failSpinner"]).toHaveBeenCalledWith(
       "Error deploying contract",
       expect.objectContaining({
-        message: expect.stringContaining("execution failed with FINISHED_WITH_ERROR"),
+        message: expect.stringContaining("leader execution result: FINISHED_WITH_ERROR"),
       }),
+    );
+  });
+
+  test("fails when deployment is undetermined despite leader return", async () => {
+    const options: DeployOptions = {
+      contract: "/mocked/contract/path",
+      args: [1, 2, 3],
+    };
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue("contract code");
+    vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "UNDETERMINED",
+      txExecutionResultName: "FINISHED_WITH_RETURN",
+    });
+
+    await deployer.deploy(options);
+
+    expect(deployer["failSpinner"]).toHaveBeenCalledWith(
+      "Error deploying contract",
+      expect.objectContaining({
+        message: expect.stringContaining("UNDETERMINED"),
+      }),
+    );
+  });
+
+  test("diagnoses leader execution timeout", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue("contract code");
+    vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
+      txExecutionResult: 3,
+    });
+
+    await deployer.deploy({contract: "/mocked/contract/path"});
+
+    expect(deployer["failSpinner"]).toHaveBeenCalledWith(
+      "Error deploying contract",
+      expect.objectContaining({
+        message: expect.stringContaining("leader timed out during execution"),
+      }),
+    );
+  });
+
+  test("diagnoses non-deterministic disagreement", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue("contract code");
+    vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
+      txExecutionResult: 4,
+    });
+
+    await deployer.deploy({contract: "/mocked/contract/path"});
+
+    expect(deployer["failSpinner"]).toHaveBeenCalledWith(
+      "Error deploying contract",
+      expect.objectContaining({
+        message: expect.stringContaining("validators disagreed on non-deterministic output"),
+      }),
+    );
+  });
+
+  test("fails when deployment is canceled", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue("contract code");
+    vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "CANCELED",
+      txExecutionResultName: "NOT_VOTED",
+    });
+
+    await deployer.deploy({contract: "/mocked/contract/path"});
+
+    expect(deployer["failSpinner"]).toHaveBeenCalledWith(
+      "Error deploying contract",
+      expect.objectContaining({
+        message: expect.stringContaining("CANCELED before execution"),
+      }),
+    );
+  });
+
+  test("accepts studio-shaped successful receipt", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue("contract code");
+    vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
+      data: {
+        contract_address: "0xdasdsadasdasdada",
+        consensus_data: {
+          leader_receipt: [{execution_result: "SUCCESS"}],
+        },
+      },
+    });
+
+    await deployer.deploy({contract: "/mocked/contract/path"});
+
+    expect(deployer["succeedSpinner"]).toHaveBeenCalledWith(
+      "Contract deployed successfully.",
+      expect.objectContaining({"Consensus Status": "ACCEPTED"}),
     );
   });
 
@@ -420,6 +538,7 @@ describe("DeployAction", () => {
     vi.mocked(fs.readFileSync).mockReturnValue(contractContent);
     vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
       txExecutionResultName: "FINISHED_WITH_RETURN",
       data: {contract_address: "0xdasdsadasdasdada"},
     });

--- a/tests/actions/estimateFees.test.ts
+++ b/tests/actions/estimateFees.test.ts
@@ -1,5 +1,5 @@
 import {describe, test, vi, beforeEach, afterEach, expect} from "vitest";
-import {createClient, createAccount} from "genlayer-js";
+import {createClient, createAccount, deriveInternalMessageCallKey} from "genlayer-js";
 import {EstimateFeesAction} from "../../src/commands/contracts/estimateFees";
 
 vi.mock("genlayer-js");
@@ -20,6 +20,9 @@ describe("EstimateFeesAction", () => {
     vi.clearAllMocks();
     vi.mocked(createClient).mockReturnValue(mockClient as any);
     vi.mocked(createAccount).mockReturnValue({privateKey: mockPrivateKey} as any);
+    vi.mocked(deriveInternalMessageCallKey).mockImplementation((methodName = "") => (
+      `0x${Buffer.from(methodName, "utf8").toString("hex").padEnd(64, "0")}` as `0x${string}`
+    ));
     action = new EstimateFeesAction();
     vi.spyOn(action as any, "getAccount").mockResolvedValue({privateKey: mockPrivateKey});
     vi.spyOn(action as any, "startSpinner").mockImplementation(() => {});

--- a/tests/actions/write.test.ts
+++ b/tests/actions/write.test.ts
@@ -1,5 +1,11 @@
 import {describe, test, vi, beforeEach, afterEach, expect} from "vitest";
-import {createClient, createAccount} from "genlayer-js";
+import {
+  createClient,
+  createAccount,
+  isSuccessful,
+  formatStakingAmount,
+  deriveExternalMessageCallKey,
+} from "genlayer-js";
 import {WriteAction} from "../../src/commands/contracts/write";
 
 vi.mock("genlayer-js");
@@ -18,6 +24,26 @@ describe("WriteAction", () => {
     vi.clearAllMocks();
     vi.mocked(createClient).mockReturnValue(mockClient as any);
     vi.mocked(createAccount).mockReturnValue({privateKey: mockPrivateKey} as any);
+    vi.mocked(formatStakingAmount).mockImplementation((value: bigint) => `${value.toString()} GEN`);
+    vi.mocked(deriveExternalMessageCallKey).mockImplementation(
+      (selectorOrCalldata: `0x${string}` | Uint8Array = "0x") => {
+        const hex = typeof selectorOrCalldata === "string"
+          ? selectorOrCalldata.slice(2)
+          : Buffer.from(selectorOrCalldata).toString("hex");
+        if (hex.length < 8) return "0x0000000000000000000000000000000000000000000000000000000000000000";
+        return `0x${hex.slice(0, 8).padEnd(64, "0")}`;
+      },
+    );
+    vi.mocked(isSuccessful).mockImplementation((receipt: any) => {
+      const statusName = receipt.statusName ?? receipt.status;
+      const executionResultName = receipt.txExecutionResultName ?? (
+        receipt.txExecutionResult === 1 ? "FINISHED_WITH_RETURN" : undefined
+      );
+      return (
+        (statusName === "ACCEPTED" || statusName === "FINALIZED") &&
+        executionResultName === "FINISHED_WITH_RETURN"
+      );
+    });
     writeAction = new WriteAction();
     vi.spyOn(writeAction as any, "getAccount").mockResolvedValue({privateKey: mockPrivateKey});
 
@@ -34,7 +60,7 @@ describe("WriteAction", () => {
   test("calls writeContract successfully", async () => {
     const options = {args: [42, "Update"]};
     const mockHash = "0xMockedTransactionHash";
-    const mockReceipt = {status: "success", txExecutionResultName: "FINISHED_WITH_RETURN"};
+    const mockReceipt = {statusName: "ACCEPTED", txExecutionResultName: "FINISHED_WITH_RETURN"};
 
     vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue(mockReceipt);
@@ -56,17 +82,18 @@ describe("WriteAction", () => {
       hash: mockHash,
       retries: 100,
       interval: 5000,
+      waitUntil: "decided",
       fullTransaction: true,
     });
     expect(writeAction["succeedSpinner"]).toHaveBeenCalledWith(
       "Write operation successfully executed",
-      mockReceipt,
+      {...mockReceipt, consensusStatus: "ACCEPTED"},
     );
   });
 
   test("calls writeContract with fee options", async () => {
     const mockHash = "0xMockedTransactionHash";
-    const mockReceipt = {status: "success", txExecutionResultName: "FINISHED_WITH_RETURN"};
+    const mockReceipt = {statusName: "ACCEPTED", txExecutionResultName: "FINISHED_WITH_RETURN"};
 
     vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue(mockReceipt);
@@ -127,7 +154,7 @@ describe("WriteAction", () => {
 
     vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
-      status: "success",
+      statusName: "ACCEPTED",
       txExecutionResultName: "FINISHED_WITH_ERROR",
     });
 
@@ -136,15 +163,112 @@ describe("WriteAction", () => {
     expect(writeAction["failSpinner"]).toHaveBeenCalledWith(
       "Error during write operation",
       expect.objectContaining({
-        message: expect.stringContaining("execution failed with FINISHED_WITH_ERROR"),
+        message: expect.stringContaining("leader execution result: FINISHED_WITH_ERROR"),
       }),
+    );
+  });
+
+  test("fails when write is undetermined despite leader return", async () => {
+    const mockHash = "0xMockedTransactionHash";
+
+    vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "UNDETERMINED",
+      txExecutionResultName: "FINISHED_WITH_RETURN",
+    });
+
+    await writeAction.write({contractAddress: "0xMockedContract", method: "updateData", args: [1]});
+
+    expect(writeAction["failSpinner"]).toHaveBeenCalledWith(
+      "Error during write operation",
+      expect.objectContaining({
+        message: expect.stringContaining("UNDETERMINED"),
+      }),
+    );
+  });
+
+  test("diagnoses leader execution timeout", async () => {
+    const mockHash = "0xMockedTransactionHash";
+
+    vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
+      txExecutionResult: 3,
+    });
+
+    await writeAction.write({contractAddress: "0xMockedContract", method: "updateData", args: [1]});
+
+    expect(writeAction["failSpinner"]).toHaveBeenCalledWith(
+      "Error during write operation",
+      expect.objectContaining({
+        message: expect.stringContaining("leader timed out during execution"),
+      }),
+    );
+  });
+
+  test("diagnoses non-deterministic disagreement", async () => {
+    const mockHash = "0xMockedTransactionHash";
+
+    vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
+      txExecutionResult: 4,
+    });
+
+    await writeAction.write({contractAddress: "0xMockedContract", method: "updateData", args: [1]});
+
+    expect(writeAction["failSpinner"]).toHaveBeenCalledWith(
+      "Error during write operation",
+      expect.objectContaining({
+        message: expect.stringContaining("validators disagreed on non-deterministic output"),
+      }),
+    );
+  });
+
+  test("fails when write is canceled", async () => {
+    const mockHash = "0xMockedTransactionHash";
+
+    vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "CANCELED",
+      txExecutionResultName: "NOT_VOTED",
+    });
+
+    await writeAction.write({contractAddress: "0xMockedContract", method: "updateData", args: [1]});
+
+    expect(writeAction["failSpinner"]).toHaveBeenCalledWith(
+      "Error during write operation",
+      expect.objectContaining({
+        message: expect.stringContaining("CANCELED before execution"),
+      }),
+    );
+  });
+
+  test("accepts studio-shaped successful receipt", async () => {
+    const mockHash = "0xMockedTransactionHash";
+
+    vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
+      data: {
+        consensus_data: {
+          leader_receipt: [{execution_result: "SUCCESS"}],
+        },
+      },
+    });
+
+    await writeAction.write({contractAddress: "0xMockedContract", method: "updateData", args: [1]});
+
+    expect(writeAction["succeedSpinner"]).toHaveBeenCalledWith(
+      "Write operation successfully executed",
+      expect.objectContaining({consensusStatus: "ACCEPTED"}),
     );
   });
 
   test("uses custom RPC URL for write operations", async () => {
     const options = {args: [42, "Update"], rpc: "https://custom-rpc-url.com"};
     const mockHash = "0xMockedTransactionHash";
-    const mockReceipt = {status: "success", txExecutionResultName: "FINISHED_WITH_RETURN"};
+    const mockReceipt = {statusName: "ACCEPTED", txExecutionResultName: "FINISHED_WITH_RETURN"};
 
     vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
     vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue(mockReceipt);
@@ -168,7 +292,7 @@ describe("WriteAction", () => {
     });
     expect(writeAction["succeedSpinner"]).toHaveBeenCalledWith(
       "Write operation successfully executed",
-      mockReceipt,
+      {...mockReceipt, consensusStatus: "ACCEPTED"},
     );
   });
 });


### PR DESCRIPTION
Follow-up to #345 closing the remaining 'accepted ≠ executed' gap one level up (designer walkthrough, 2026-06-09).

- `txExecutionResult` is the **leader's** result, written at reveal even when the round ends UNDETERMINED — so the existing check could print *'deployed successfully'* with an address that never materializes. Success now also requires status ∈ {ACCEPTED, FINALIZED} (via genlayer-js `isSuccessful`); failures name both the consensus outcome and the leader result.
- VoteType 3/4 mapped with real diagnoses (TIMEOUT / NONDET_DISAGREE) instead of 'did not expose an execution result'.
- deploy/write use the new `waitUntil: 'decided'` API; explicit fee deposits echoed before sending; reached status reported after success.
- callKey derivation deduplicated — imported from genlayer-js (incl. `DEPLOY_CALL_KEY`), removing a byte-for-byte copy that would silently drift.

Depends on genlayerlabs/genlayer-js#187 (waitUntil/isSuccessful APIs). 530 tests green incl. new negative coverage (UNDETERMINED, CANCELED, VoteType 3/4, Studio-shape).