### PR TITLE
fix(system): propagate command-check and version parse fixes to v0.40-dev

### DIFF
--- a/src/lib/clients/system.ts
+++ b/src/lib/clients/system.ts
@@ -9,9 +9,7 @@ export async function checkCommand(command: string, toolName: string): Promise<v
   try {
     await util.promisify(exec)(command);
   }catch (error:any) {
-    if (error.stderr) {
-      throw new MissingRequirementError(toolName);
-    }
+    throw new MissingRequirementError(toolName);
   }
 }
 
@@ -50,24 +48,28 @@ export function openUrl(url: string): Promise<ChildProcess> {
 }
 
 export async function getVersion(toolName: string): Promise<string> {
+  let toolResponse: {stdout?: string; stderr?: string};
+
   try {
-    const toolResponse = await util.promisify(exec)(`${toolName} --version`);
-
-    if (toolResponse.stderr) {
-      throw new Error(toolResponse.stderr);
-    }
-
-    try {
-      const versionMatch = toolResponse.stdout.match(/(\d+\.\d+\.\d+)/);
-      if (versionMatch) {
-        return versionMatch[1];
-      }
-    } catch (err) {
-      throw new Error(`Could not parse ${toolName} version.`);
-    }
+    toolResponse = await util.promisify(exec)(`${toolName} --version`);
   } catch (error) {
     throw new Error(`Error getting ${toolName} version.`);
   }
 
-  return "";
+  if (toolResponse.stderr) {
+    throw new Error(`Error getting ${toolName} version.`);
+  }
+
+  if (toolResponse.stdout == null) {
+    throw new Error(`Error getting ${toolName} version.`);
+  }
+
+  const versionMatch = toolResponse.stdout.match(/(\d+\.\d+\.\d+)/);
+  if (versionMatch) {
+    return versionMatch[1];
+  }
+
+  throw new Error(
+    `Could not parse ${toolName} version from output: "${toolResponse.stdout}". Expected format: X.Y.Z`
+  );
 }

--- a/tests/libs/system.test.ts
+++ b/tests/libs/system.test.ts
@@ -70,13 +70,15 @@ describe("System Functions - Error Paths", () => {
     await expect(getVersion(toolName)).rejects.toThrow(`Error getting ${toolName} version.`);
   });
 
-  test("getVersion returns '' if stdout is empty", async () => {
+  test("getVersion throws when stdout does not match version pattern", async () => {
     vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.resolve({
       stdout: "",
       stderr: ""
     }));
-    const result = await getVersion('git');
-    expect(result).toBe("");
+    const toolName = "git";
+    await expect(getVersion(toolName)).rejects.toThrow(
+      `Could not parse ${toolName} version from output`
+    );
   });
 
   test("getVersion throw error if stdout undefined", async () => {
@@ -87,12 +89,43 @@ describe("System Functions - Error Paths", () => {
     await expect(getVersion(toolName)).rejects.toThrow(`Error getting ${toolName} version.`);
   });
 
+  test("getVersion throws when stdout has non-matching version format (e.g. major-only)", async () => {
+    vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.resolve({
+      stdout: "Docker version 25",
+      stderr: ""
+    }));
+    const toolName = "docker";
+    await expect(getVersion(toolName)).rejects.toThrow(
+      `Could not parse ${toolName} version from output`
+    );
+  });
+
   test("checkCommand returns false if the command does not exist", async () => {
     vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.reject({
       stdout: "",
       stderr: "command not found"
     }));
     const toolName = 'nonexistent';
+    await expect(checkCommand(`${toolName} --version`, toolName)).rejects.toThrow(new MissingRequirementError(toolName));
+  });
+
+  test("checkCommand throws MissingRequirementError when binary is not installed (ENOENT)", async () => {
+    vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.reject({
+      code: 'ENOENT',
+      stderr: '',
+      message: 'spawn ENOENT'
+    }));
+    const toolName = 'docker';
+    await expect(checkCommand(`${toolName} --version`, toolName)).rejects.toThrow(new MissingRequirementError(toolName));
+  });
+
+  test("checkCommand throws MissingRequirementError when command exits without stderr", async () => {
+    vi.mocked(util.promisify).mockReturnValueOnce(() => Promise.reject({
+      code: 127,
+      stderr: '',
+      message: 'command failed'
+    }));
+    const toolName = 'docker';
     await expect(checkCommand(`${toolName} --version`, toolName)).rejects.toThrow(new MissingRequirementError(toolName));
   });
 


### PR DESCRIPTION
Propagates the stable fix merged in #349 to the next dev line.

Includes:
- command checks now fail closed on any rejected exec
- version parsing now throws on empty or non-matching stdout
- regression tests for ENOENT, no-stderr command failures, and non-matching version output

Verification on this branch:
- `npm run test -- tests/libs/system.test.ts`
- `npm run build`