### PR TITLE
Release v0.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.39.2](https://github.com/genlayerlabs/genlayer-cli/compare/v0.39.1...v0.39.2) (2026-06-11)
+
+### Features
+
+* add v0.6 fee-aware commands ([#340](https://github.com/genlayerlabs/genlayer-cli/issues/340)) ([ca083ab](https://github.com/genlayerlabs/genlayer-cli/commit/ca083abbf854960a6638d5af63096b532a03cc5a))
+* branch-per-major release model ([#311](https://github.com/genlayerlabs/genlayer-cli/issues/311)) ([6fd2f3a](https://github.com/genlayerlabs/genlayer-cli/commit/6fd2f3a678ce348c92470828b03bdfc596afa9cb)), closes [genlayer-js#172](https://github.com/genlayerlabs/genlayer-js/issues/172)
+
+### Bug Fixes
+
+* **localnet:** print validator count to stdout ([37519e1](https://github.com/genlayerlabs/genlayer-cli/commit/37519e18b6155bc762fa24ea809a53c3e83ac9a7))
+* run CI on v0.39 branch ([#322](https://github.com/genlayerlabs/genlayer-cli/issues/322)) ([e129bab](https://github.com/genlayerlabs/genlayer-cli/commit/e129bab0c471c2d59d360b5ca8c1cb3190774ff8))
+* **system:** handle command-check and version parse failures ([#349](https://github.com/genlayerlabs/genlayer-cli/issues/349)) ([5b93dd3](https://github.com/genlayerlabs/genlayer-cli/commit/5b93dd32e45683f30368d0c9324078800c3d8dda)), closes [#301](https://github.com/genlayerlabs/genlayer-cli/issues/301) [#303](https://github.com/genlayerlabs/genlayer-cli/issues/303)
+
 ## 0.39.1 (2026-05-06)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genlayer",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genlayer",
-      "version": "0.39.1",
+      "version": "0.39.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genlayer",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "GenLayer Command Line Tool",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
Cuts the `v0.39.2` stable release after #349.

Includes:
- `package.json` / `package-lock.json` version bump to `0.39.2`
- `CHANGELOG.md` entry generated by release-it

Local verification before opening this PR:
- `npm run test:coverage` — 49 files, 521 tests passed
- `npm run build`

Note: direct release push was blocked by branch rules requiring `E2E Tests`, so this release is going through a PR. After merge, the `v0.39.2` tag should be created on the merged release commit to trigger `publish.yml`.