### PR TITLE
fix: drop getSlashingAddress from validator-history (port of #344 to v0.40-dev)

### DIFF
--- a/src/commands/staking/validatorHistory.ts
+++ b/src/commands/staking/validatorHistory.ts
@@ -1,6 +1,6 @@
 import {StakingAction, StakingConfig, BUILT_IN_NETWORKS} from "./StakingAction";
 import type {Address, GenLayerChain} from "genlayer-js/types";
-import {createPublicClient, http} from "viem";
+import {createPublicClient, http, getContract} from "viem";
 import Table from "cli-table3";
 import chalk from "chalk";
 
@@ -104,7 +104,35 @@ export class ValidatorHistoryAction extends StakingAction {
 
       // Get addresses
       const stakingAddress = client.getStakingContract().address;
-      const slashingAddress = await client.getSlashingAddress();
+
+      // getSlashingAddress() was removed in SDK v0.39+.
+      // Read idleness contract address from AddressManager via viem.
+      const ADDRESS_MANAGER_ABI = [{
+        type: "function",
+        name: "getIdlenessAddress",
+        stateMutability: "view",
+        inputs: [],
+        outputs: [{ name: "", type: "address" }],
+      }] as const;
+
+      // Fallback: use staking address if idleness address cannot be resolved
+      let slashingAddress: string = stakingAddress;
+      try {
+        const tempClient = createPublicClient({
+          chain,
+          transport: http(chain.rpcUrls.default.http[0]),
+        });
+        const consensusAddress = chain.consensusMainContract?.address as `0x${string}` | undefined;
+        if (consensusAddress) {
+          slashingAddress = await tempClient.readContract({
+            address: consensusAddress,
+            abi: ADDRESS_MANAGER_ABI,
+            functionName: "getIdlenessAddress",
+          }) as string;
+        }
+      } catch (_) {
+        // If resolution fails, slash events won't be fetched but reward events will still work
+      }
 
       // Create public client for log fetching
       const publicClient = createPublicClient({


### PR DESCRIPTION
## Summary

Ports the fix from #344 to the active `v0.40-dev` line. The original PR #344 targets the now-dead `v0.39` branch, but the same bug is still present on `v0.40-dev` (`src/commands/staking/validatorHistory.ts:107` still calls `client.getSlashingAddress()`).

## Bug

`genlayer staking validator-history` crashes with `client.getSlashingAddress is not a function`. `getSlashingAddress()` was removed from the `genlayer-js` SDK (v0.39+ / current `v2-dev` pin). Verified: the installed SDK exports no `getSlashingAddress` symbol, while `consensusMainContract` is present on the chain type.

## Fix

Resolve the idleness (slashing) contract address dynamically via viem `readContract` against `consensusMainContract.getIdlenessAddress()`, with a fallback to the staking contract address if resolution fails so reward events still display.

## Verification

- `npm run build` clean
- `vitest run` — 563/563 passing
- `validatorHistory.ts` is `tsc --noEmit` clean (the 31 pre-existing `tsc` errors on `v0.40-dev` are unrelated SDK `v2-dev` type drift in other staking files)

## Credit

Original fix authored by @ygd58 in #344. This PR is a straight port (patch applies cleanly to `v0.40-dev`).

Supersedes #344.
Fixes #341