### PR TITLE
ci: add npm dist-tag channel workflow

### DIFF
--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -1,0 +1,81 @@
+name: Manage npm dist-tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_version:
+        description: "Published genlayer version to point the dist-tag at, e.g. 0.40.0-rc2"
+        required: true
+        type: string
+      dist_tag:
+        description: "npm dist-tag to set, e.g. clarke"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  set-dist-tag:
+    runs-on: ubuntu-latest
+    environment: Publish
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Validate inputs
+        env:
+          PACKAGE_VERSION: ${{ inputs.package_version }}
+          DIST_TAG: ${{ inputs.dist_tag }}
+        run: |
+          set -euo pipefail
+
+          PACKAGE_VERSION="${PACKAGE_VERSION#v}"
+
+          if [[ ! "$PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z._-]+)?(\+[0-9A-Za-z._-]+)?$ ]]; then
+            echo "Invalid package_version: $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+          if [[ ! "$DIST_TAG" =~ ^[A-Za-z][A-Za-z0-9._-]*$ ]]; then
+            echo "Invalid dist_tag: $DIST_TAG" >&2
+            exit 1
+          fi
+
+          if [ "$DIST_TAG" = "latest" ]; then
+            echo "This workflow intentionally refuses to move latest." >&2
+            exit 1
+          fi
+
+          if [[ "$DIST_TAG" =~ ^v?[0-9] ]]; then
+            echo "Invalid dist_tag '$DIST_TAG': dist-tags must not look like versions." >&2
+            exit 1
+          fi
+
+          PUBLISHED_VERSION="$(npm view "genlayer@$PACKAGE_VERSION" version)"
+          if [ "$PUBLISHED_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Published package mismatch: requested $PACKAGE_VERSION, npm returned $PUBLISHED_VERSION" >&2
+            exit 1
+          fi
+
+          {
+            echo "package_version=$PACKAGE_VERSION"
+            echo "dist_tag=$DIST_TAG"
+          } >> "$GITHUB_ENV"
+
+      - name: Set npm dist-tag
+        run: npm dist-tag add "genlayer@$package_version" "$dist_tag"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify npm dist-tag
+        run: |
+          set -euo pipefail
+          ACTUAL_VERSION="$(npm view "genlayer@$dist_tag" version)"
+          if [ "$ACTUAL_VERSION" != "$package_version" ]; then
+            echo "dist-tag $dist_tag points at $ACTUAL_VERSION, expected $package_version" >&2
+            exit 1
+          fi
+          echo "genlayer@$dist_tag -> $ACTUAL_VERSION"


### PR DESCRIPTION
## Summary
- add a manual workflow for moving named npm dist-tags such as clarke
- use the existing Publish environment and NPM_TOKEN
- reject latest and version-looking dist-tags
- verify the final npm dist-tag mapping after update

## Use case
Set genlayer@clarke -> 0.40.0-rc2 for the Clarke staking guide without publishing a new package.

## Verification
- inspected workflow validation and command path