### PR TITLE
ci: use npm auth token secret for package operations

### DIFF
--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set npm dist-tag
         run: npm dist-tag add "genlayer@$package_version" "$dist_tag"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN || secrets.NPM_TOKEN }}
 
       - name: Verify npm dist-tag
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance --access public --tag "${{ steps.version.outputs.npm_dist_tag }}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN || secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary
- use the repo's NPM_AUTH_TOKEN secret for npm publish/dist-tag operations
- keep NPM_TOKEN as a fallback for compatibility

## Context
The genlayer@clarke dist-tag workflow failed because NODE_AUTH_TOKEN was empty when referencing NPM_TOKEN. The repo secret present today is NPM_AUTH_TOKEN.

## Verification
- listed repo/environment secret names only
- checked the failed workflow log showed empty NODE_AUTH_TOKEN