### PR TITLE
test: make wallet session descriptor tests portable

### DIFF
--- a/tests/libs/sessionDescriptor.test.ts
+++ b/tests/libs/sessionDescriptor.test.ts
@@ -42,14 +42,16 @@ describe("sessionDescriptor", () => {
 
   test("descriptorPath resolves against the config manager folder", () => {
     const fake = {getFilePath: (n: string) => path.join("/home/x/.genlayer", n)} as any;
-    expect(descriptorPath(fake)).toBe("/home/x/.genlayer/wallet-session.json");
+    expect(descriptorPath(fake)).toBe(path.join("/home/x/.genlayer", "wallet-session.json"));
   });
 
   test("writeDescriptor writes 0600 and readDescriptor round-trips", () => {
     const d = makeDescriptor();
     writeDescriptor(file, d);
     const mode = fs.statSync(file).mode & 0o777;
-    expect(mode).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect(mode).toBe(0o600);
+    }
     expect(readDescriptor(file)).toEqual(d);
     // No leftover temp file.
     expect(fs.existsSync(`${file}.tmp`)).toBe(false);


### PR DESCRIPTION
Fixes the Windows-only CI failure in wallet session descriptor tests before cutting the next Clarke prerelease.\n\nChanges:\n- compare descriptor paths using platform-native path.join\n- skip Unix 0600 mode assertion on Windows, where chmod semantics do not match POSIX\n\nLocal verification:\n- npm test -- tests/libs/sessionDescriptor.test.ts\n- npm run build