### PR TITLE
fix: config reset no longer writes undefined value to disk

### DIFF
--- a/src/commands/config/getSetReset.ts
+++ b/src/commands/config/getSetReset.ts
@@ -44,8 +44,7 @@ export class ConfigActions extends BaseAction {
       return;
     }
 
-    delete config[key];
-    this.writeConfig(key, undefined);
+    this.removeConfig(key);
     this.succeedSpinner(`Configuration successfully reset`);
   }
 }


### PR DESCRIPTION
## Summary

Fixes dead code in the `config reset` command where the key was never actually removed from disk.

## Problem

The `reset()` method had two bugs:
1. `delete config[key]` — removes the key from the in-memory object only
2. `writeConfig(key, undefined)` — immediately writes `key: undefined` back to disk, undoing the deletion

As a result, `genlayer config reset <key>` appeared to succeed but the config file was unchanged.

Fixes #305

## Fix

Replace both lines with `this.removeConfig(key)` which correctly deletes the key from the in-memory config object and persists the change to disk in a single operation.

## Changes

- `src/commands/config/getSetReset.ts`: removed dead `delete config[key]` line and replaced `writeConfig(key, undefined)` with `removeConfig(key)`