### PR TITLE
fix: setNetwork ignores empty string argument and shows interactive prompt

### DIFF
--- a/src/commands/config/getSetReset.ts
+++ b/src/commands/config/getSetReset.ts
@@ -44,8 +44,7 @@ export class ConfigActions extends BaseAction {
       return;
     }
 
-    delete config[key];
-    this.writeConfig(key, undefined);
+    this.removeConfig(key);
     this.succeedSpinner(`Configuration successfully reset`);
   }
 }

--- a/src/commands/network/setNetwork.ts
+++ b/src/commands/network/setNetwork.ts
@@ -98,7 +98,7 @@ export class NetworkActions extends BaseAction {
   async setNetwork(networkName?: string): Promise<void> {
     const entries = this.getNetworkEntries();
 
-    if (networkName || networkName === "") {
+    if (networkName) {
       const selectedNetwork = entries.find(n =>
         n.alias === networkName || (n.type === "built-in" && n.name === networkName),
       );


### PR DESCRIPTION
## Summary

Fixes `setNetwork` treating empty string `""` as a valid network name instead of falling through to the interactive prompt.

## Problem

The condition `if (networkName || networkName === "")` evaluates to `true` for empty strings. This causes the command to search for a network named `""`, fail to find it, and show an error — instead of showing the interactive network selection prompt.

Fixes #306

## Fix

Simplify the condition to `if (networkName)` so that empty strings are treated the same as `undefined`, correctly triggering the interactive prompt.

## Before / After

```bash
# Before
genlayer network set ""
# → Error: Network  not found

# After
genlayer network set ""
# → Shows interactive network selection prompt
```