### PR TITLE
docs(cli): document browser-wallet signing, custom networks, balances, vesting wizard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ npx vitest -t "test name pattern"         # Run specific test by name
 ### Entry Point & Command Structure
 - `src/index.ts` - Main entry, initializes Commander program and registers all command groups
 - Commands organized in `src/commands/<domain>/index.ts` - each exports `initialize*Commands(program)` function
-- Command domains: general (init/up/stop), account, contracts, config, localnet, update, scaffold, network, transactions, staking
+- Command domains: general (init/up/stop), account, contracts, config, localnet, update, scaffold, network, transactions, staking, vesting, wallet, balances
+- Custom networks: `network add <alias> --base <built-in>` registers a custom network profile (RPC/contract-address overrides); resolved by alias everywhere via `--network`
+- Browser-wallet signing: write commands (staking/vesting/deploy/write) accept `--wallet browser` to sign in MetaMask through a local bridge (`addWalletModeOption` in `src/lib/wallet/walletOption.ts`); `wallet connect` starts a persistent session so the key never leaves MetaMask
 
 ### Core Classes
 - `BaseAction` (`src/lib/actions/BaseAction.ts`) - Base class for all CLI actions. Provides:

--- a/README.md
+++ b/README.md
@@ -151,14 +151,33 @@ USAGE:
    genlayer network set [network]    Set the network to use
    genlayer network info             Show current network configuration and contract addresses
    genlayer network list             List available networks
+   genlayer network add <alias>      Add a custom network profile
+   genlayer network remove <alias>   Remove a custom network profile
+
+OPTIONS (add):
+   --base <built-in-alias>    Built-in base network to derive from (required)
+   --rpc <url>                Node RPC URL override
+   --chain-id <n>             Chain ID override
+   --consensus-main <addr>    ConsensusMain contract address override
+   --consensus-data <addr>    ConsensusData contract address override
+   --staking <addr>           Staking contract address override
+   --fee-manager <addr>       FeeManager contract address override
+   --deployment <path.json>   Consensus deployments JSON file to read addresses from
 
 EXAMPLES:
    genlayer network set
-   genlayer network set testnet
-   genlayer network set mainnet
+   genlayer network set testnet-bradbury
    genlayer network info
    genlayer network list
+
+   # Register a custom network on top of a built-in base, then use it by alias
+   genlayer network add my-devnet --base testnet-bradbury --rpc https://rpc.example.com --chain-id 4221
+   genlayer network set my-devnet
+   genlayer deploy --network my-devnet
 ```
+
+Custom networks are stored by alias and can be selected anywhere a built-in
+network can, via `--network <alias>` (or `genlayer network set <alias>`).
 
 #### Deploy and Call Intelligent Contracts
 
@@ -583,6 +602,80 @@ EXAMPLES:
 
    # Prime all validators that need priming (anyone can call)
    genlayer staking prime-all
+```
+
+#### Browser Wallet Signing
+
+By default, write commands sign with your encrypted keystore. Any write command
+(`deploy`, `write`, and the `staking`/`vesting` commands) also accepts
+`--wallet browser` to sign in MetaMask instead: the CLI serves a small page on
+`127.0.0.1`, opens it, and you connect and confirm in the wallet. Your private
+key never leaves MetaMask.
+
+To avoid reconnecting for every command, open a persistent session once with
+`wallet connect` and reuse it across subsequent `--wallet browser` commands.
+
+```bash
+USAGE:
+   genlayer wallet connect [options]   Start a persistent browser-wallet session (connect once)
+   genlayer wallet status              Show the current session (address, network, heartbeat)
+   genlayer wallet disconnect          End the active session
+
+EXAMPLES:
+   # Connect once, then reuse across commands
+   genlayer wallet connect --network testnet-bradbury
+   genlayer deploy --wallet browser
+   genlayer write 0x123...abc updateValue --args 42 --wallet browser
+   genlayer wallet status
+   genlayer wallet disconnect
+```
+
+For remote/SSH hosts, forward the printed port first
+(`ssh -L <port>:127.0.0.1:<port> ...`). The default signing mode can be set via
+the `walletMode` config value.
+
+#### Balances
+
+Show wallet and vesting balances plus committed stake for an address
+(read-only, no keystore unlock).
+
+```bash
+USAGE:
+   genlayer balances [options]
+
+OPTIONS:
+   --beneficiary <address>  Address to inspect (defaults to the active account)
+   --account <name>         Account whose address to use (no unlock)
+   --network <network>      Built-in or custom network alias
+   --rpc <rpcUrl>           RPC URL for the network
+
+EXAMPLES:
+   genlayer balances
+   genlayer balances --beneficiary 0x123...abc --network testnet-bradbury
+```
+
+#### Vesting
+
+Manage vesting contracts and vesting-backed validators. Beneficiaries can list
+their vesting contracts, delegate/withdraw vested tokens, and run validators
+whose stake is committed from a vesting contract rather than their wallet.
+
+```bash
+USAGE:
+   genlayer vesting list                     List beneficiary vesting contracts and state
+   genlayer vesting delegate <validator>     Delegate vesting-held tokens to a validator
+   genlayer vesting withdraw --amount <amt>   Withdraw vested tokens to the beneficiary
+   genlayer vesting validator create [operator] --amount <amt>  Create a vesting-backed validator
+   genlayer vesting validator list           List validator wallets owned by a vesting contract
+```
+
+The `staking wizard` can fund a validator from either your wallet or a vesting
+contract, and sign with a keystore key or a browser wallet — the recommended
+path for creating a vesting-backed validator interactively:
+
+```bash
+genlayer staking wizard
+genlayer staking wizard --wallet browser
 ```
 
 ### Running the CLI from the repository

--- a/docs/api-references/_meta.json
+++ b/docs/api-references/_meta.json
@@ -7,6 +7,7 @@
   "accounts": "Accounts",
   "staking": "Staking",
   "localnet": "Localnet",
+  "balances": "balances",
   "estimate-fees": "estimate-fees",
   "finalize": "finalize",
   "finalize-batch": "finalize-batch",

--- a/docs/api-references/accounts/account/show.mdx
+++ b/docs/api-references/accounts/account/show.mdx
@@ -13,5 +13,6 @@ Show account details (address, balance)
 | Short | Long | Description | Required | Default |
 | --- | --- | --- | :---: | --- |
 |  | --rpc &lt;rpcUrl&gt; | RPC URL for the network | No |  |
+|  | --network &lt;network&gt; | built-in or custom network alias (see: genlayer network list) | No |  |
 |  | --account &lt;name&gt; | Account to show | No |  |
 | -h | --help | display help for command | No |  |

--- a/docs/api-references/balances.mdx
+++ b/docs/api-references/balances.mdx
@@ -1,0 +1,19 @@
+---
+title: balances
+---
+
+Show wallet + vesting balances and committed stake (read-only)
+
+### Usage
+
+`$ genlayer balances [options]`
+
+### Options
+
+| Short | Long | Description | Required | Default |
+| --- | --- | --- | :---: | --- |
+|  | --beneficiary &lt;address&gt; | Address to inspect (defaults to the active account, no unlock) | No |  |
+|  | --network &lt;network&gt; | built-in or custom network alias (see: genlayer network list) | No |  |
+|  | --rpc &lt;rpcUrl&gt; | RPC URL for the network | No |  |
+|  | --account &lt;name&gt; | Account whose address to use (no unlock) | No |  |
+| -h | --help | display help for command | No |  |

--- a/docs/api-references/index.mdx
+++ b/docs/api-references/index.mdx
@@ -6,7 +6,7 @@ GenLayer CLI is a development environment for the GenLayer ecosystem. It allows
 developers to interact with the protocol by creating accounts, sending
 transactions, and working with Intelligent Contracts by testing, debugging, and
 deploying them.
-Version: `0.39.1`
+Version: `0.40.0-clarke.2`
 
 ### Command List
 
@@ -34,6 +34,7 @@ Version: `0.39.1`
 - `genlayer staking` — Staking operations for validators and delegators
 - `genlayer vesting` — Vesting operations for beneficiaries
 - `genlayer wallet` — Manage the persistent browser-wallet (MetaMask) signing session
+- `genlayer balances` — Show wallet + vesting balances and committed stake (read-only)
 
 ---
 

--- a/docs/api-references/staking/staking.mdx
+++ b/docs/api-references/staking/staking.mdx
@@ -20,7 +20,7 @@ Staking operations for validators and delegators
 
 ### Subcommands
 
-- `genlayer wizard` — Interactive wizard to become a validator
+- `genlayer wizard` — Interactive wizard to become a validator: funds the stake from your wallet or a vesting contract, and signs with a keystore key or a browser wallet (--wallet browser)
 - `genlayer validator-join` — Join as a validator by staking tokens
 - `genlayer validator-deposit` — Make an additional deposit to a validator wallet
 - `genlayer validator-exit` — Exit as a validator by withdrawing shares

--- a/docs/api-references/staking/staking/wizard.mdx
+++ b/docs/api-references/staking/staking/wizard.mdx
@@ -2,7 +2,9 @@
 title: staking wizard
 ---
 
-Interactive wizard to become a validator
+Interactive wizard to become a validator: funds the stake from your wallet or a
+vesting contract, and signs with a keystore key or a browser wallet (--wallet
+browser)
 
 ### Usage
 

--- a/src/commands/staking/index.ts
+++ b/src/commands/staking/index.ts
@@ -23,7 +23,7 @@ export function initializeStakingCommands(program: Command) {
   addWalletModeOption(
     staking
       .command("wizard")
-      .description("Interactive wizard to become a validator")
+      .description("Interactive wizard to become a validator: funds the stake from your wallet or a vesting contract, and signs with a keystore key or a browser wallet (--wallet browser)")
       .option("--account <name>", "Account to use (skip selection)")
       .option("--network <network>", "Network to use (skip selection)")
       .option("--skip-identity", "Skip identity setup step")


### PR DESCRIPTION
## Summary

Finishes the `--help` + repo-docs pass for the browser-wallet, balances, custom-network, and vesting-wizard features. Docs are auto-generated (`npm run docs:cli` from the command tree), so source command descriptions were improved and the `docs/api-references/**` were regenerated.

## Changes

- **`docs/api-references/balances.mdx` now generated** — `docs:cli` hadn't been re-run after the `balances` command landed; regenerating adds the page and refreshes `_meta.json` / `index.mdx`. Also picks up a stale `account show --network` option and the wizard description.
- **`staking wizard` description expanded** (`src/commands/staking/index.ts`) — now notes it funds from your wallet or a vesting contract and signs with a keystore key or browser wallet.
- **CLAUDE.md** — "Command domains" line now lists `vesting`, `wallet`, `balances`, plus notes on custom networks (`network add`) and browser-wallet signing.
- **README.md** — added/refreshed coverage of browser-wallet signing (connect-once via `wallet connect` + `--wallet browser`, key never leaves MetaMask), custom networks (`network add <alias>`), the `balances` command, and vesting-backed validators via the wizard.

## Verification

- `npm run build` clean; `npx vitest run` green (733 tests).
- `tsc --noEmit` = 32 errors (unchanged baseline, zero new).
- `npm run docs:cli` is idempotent — a second run produces no further diff.