### PR TITLE
fix(wallet): harden browser-signing bridge (security review)

### DIFF
--- a/src/commands/wallet/WalletAction.ts
+++ b/src/commands/wallet/WalletAction.ts
@@ -83,7 +83,10 @@ export class WalletAction extends BaseAction {
     const client = new WalletSessionClient(ready);
     const state = await client.state();
     this.logInfo(`Open this URL in a browser with your wallet to connect:\n  ${state.url}`);
-    this.logInfo("(Remote/SSH? Forward the port first: ssh -L <port>:127.0.0.1:<port> ...)");
+    this.logInfo(
+      "(Remote/SSH? Forward the port first: ssh -L <port>:127.0.0.1:<port> ...; " +
+        "do not use -g, GatewayPorts yes, or bind the local side to a public interface.)",
+    );
 
     this.startSpinner("Waiting for wallet connection...");
     try {

--- a/src/lib/config/ConfigFileManager.ts
+++ b/src/lib/config/ConfigFileManager.ts
@@ -26,14 +26,16 @@ export class ConfigFileManager {
 
   private ensureFolderExists(): void {
     if (!fs.existsSync(this.folderPath)) {
-      fs.mkdirSync(this.folderPath, { recursive: true });
+      fs.mkdirSync(this.folderPath, { recursive: true, mode: 0o700 });
     }
+    fs.chmodSync(this.folderPath, 0o700);
   }
 
   private ensureKeystoresDirExists(): void {
     if (!fs.existsSync(this.keystoresPath)) {
-      fs.mkdirSync(this.keystoresPath, { recursive: true });
+      fs.mkdirSync(this.keystoresPath, { recursive: true, mode: 0o700 });
     }
+    fs.chmodSync(this.keystoresPath, 0o700);
   }
 
   private ensureConfigFileExists(): void {

--- a/src/lib/wallet/bridgePage.ts
+++ b/src/lib/wallet/bridgePage.ts
@@ -63,6 +63,7 @@ export const BRIDGE_PAGE_HTML = /* html */ `<!doctype html>
 <script>
 (function () {
   var TOKEN = (new URLSearchParams(location.hash.slice(1))).get("s") || "";
+  if (TOKEN) history.replaceState(null, "", location.pathname);
   var statusEl = document.getElementById("status");
   var txEl = document.getElementById("tx");
   var actionBtn = document.getElementById("action");
@@ -90,6 +91,10 @@ export const BRIDGE_PAGE_HTML = /* html */ `<!doctype html>
     });
     opts.cache = "no-store";
     return fetch(path, opts);
+  }
+
+  async function postConnectedAddress() {
+    await api("/api/connected", {method: "POST", body: JSON.stringify({address: connectedAddress})});
   }
 
   function toHexQuantity(v) {
@@ -145,13 +150,31 @@ export const BRIDGE_PAGE_HTML = /* html */ `<!doctype html>
     setStatus("Checking network…");
     await ensureChain();
 
-    await api("/api/connected", {method: "POST", body: JSON.stringify({address: connectedAddress})});
+    await postConnectedAddress();
     setStatus("Connected as " + connectedAddress + ". Waiting for the CLI…", "ok");
 
     if (window.ethereum.on) {
       window.ethereum.on("accountsChanged", function (accts) {
-        connectedAddress = accts && accts[0] ? accts[0] : connectedAddress;
-        setStatus("Account changed to " + connectedAddress + ". The CLI will verify the sender.", "warn");
+        void (async function () {
+          var nextAddress = accts && accts[0];
+          if (!nextAddress) {
+            stopped = true;
+            connectedAddress = null;
+            setStatus("Wallet account disconnected. Reconnect with the CLI to continue.", "err");
+            return;
+          }
+          connectedAddress = nextAddress;
+          try {
+            await postConnectedAddress();
+            setStatus(
+              "Account changed to " + connectedAddress + ". The CLI will only accept results from this account.",
+              "warn",
+            );
+          } catch (err) {
+            stopped = true;
+            setStatus("Account changed, but the CLI bridge could not update the signer. Reconnect the wallet session.", "err");
+          }
+        })();
       });
     }
 

--- a/src/lib/wallet/browserBridge.ts
+++ b/src/lib/wallet/browserBridge.ts
@@ -1,5 +1,5 @@
 import http from "node:http";
-import {randomUUID} from "node:crypto";
+import {randomUUID, timingSafeEqual} from "node:crypto";
 import type {AddressInfo} from "node:net";
 import {hexToBigInt} from "viem";
 import type {Address, Hash} from "genlayer-js/types";
@@ -134,6 +134,7 @@ interface PendingTx {
   reject: (err: Error) => void;
   timer?: NodeJS.Timeout;
   delivered: boolean;
+  expectedSigner?: Address;
   from?: Address;
 }
 
@@ -144,7 +145,19 @@ interface NextWaiter {
 
 const DEFAULT_CONNECT_TIMEOUT = 180_000;
 const DEFAULT_TX_TIMEOUT = 300_000;
+const MAX_JSON_BODY_BYTES = 64 * 1024;
 // LONG_POLL_MS is imported from ./sessionConstants (single source of truth).
+
+class PayloadTooLargeError extends Error {
+  constructor() {
+    super("Request body too large");
+    this.name = "PayloadTooLargeError";
+  }
+}
+
+function sameAddress(a: Address, b: Address): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
 
 /**
  * Dependency-free localhost bridge that lets a browser wallet (MetaMask, any
@@ -171,6 +184,7 @@ export class BrowserWalletBridge {
 
   private readonly token = randomUUID();
   private server: http.Server | null = null;
+  private boundPort = 0;
   private origin = "";
   private url = "";
   private closed = false;
@@ -252,6 +266,7 @@ export class BrowserWalletBridge {
     });
 
     const address = this.server.address() as AddressInfo;
+    this.boundPort = address.port;
     this.origin = `http://127.0.0.1:${address.port}`;
     this.url = `${this.origin}/#s=${this.token}`;
 
@@ -372,6 +387,7 @@ export class BrowserWalletBridge {
         resolve,
         reject,
         delivered: false,
+        expectedSigner: this.connectedAddress ?? undefined,
       };
       pending.timer = setTimeout(() => {
         const idx = this.txQueue.indexOf(pending);
@@ -444,6 +460,12 @@ export class BrowserWalletBridge {
   private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     res.setHeader("Cache-Control", "no-store");
 
+    if (!this.isValidHost(req.headers.host)) {
+      res.statusCode = 403;
+      res.end("Bad host");
+      return;
+    }
+
     const url = new URL(req.url ?? "/", this.origin);
     const path = url.pathname;
 
@@ -460,7 +482,7 @@ export class BrowserWalletBridge {
     }
 
     // Token auth for all API routes.
-    if (req.headers["x-bridge-token"] !== this.token) {
+    if (!this.isValidToken(req.headers["x-bridge-token"])) {
       res.statusCode = 403;
       res.end("Forbidden");
       return;
@@ -508,21 +530,23 @@ export class BrowserWalletBridge {
         res.end("Not found");
         return;
       }
-      void this.readJson(req).then(body => {
-        try {
-          const parsed = parseBridgeTx(body as SerializedBridgeTx);
-          const id = this.enqueueTx(parsed);
-          this.json(res, {id});
-        } catch (err) {
-          if (err instanceof EnqueueError) {
-            res.statusCode = 409;
-            this.json(res, {error: err.reason});
-          } else {
-            res.statusCode = 400;
-            this.json(res, {error: (err as Error)?.message || "bad request"});
+      void this.readJson(req)
+        .then(body => {
+          try {
+            const parsed = parseBridgeTx(body as SerializedBridgeTx);
+            const id = this.enqueueTx(parsed);
+            this.json(res, {id});
+          } catch (err) {
+            if (err instanceof EnqueueError) {
+              res.statusCode = 409;
+              this.json(res, {error: err.reason});
+            } else {
+              res.statusCode = 400;
+              this.json(res, {error: (err as Error)?.message || "bad request"});
+            }
           }
-        }
-      });
+        })
+        .catch(err => this.handleJsonReadError(res, err));
       return;
     }
 
@@ -554,21 +578,23 @@ export class BrowserWalletBridge {
     }
 
     if (path === "/api/connected" && req.method === "POST") {
-      void this.readJson(req).then(body => {
-        const address = (body?.address ?? "") as Address;
-        this.connectedAddress = address;
-        if (this.connectTimer) {
-          clearTimeout(this.connectTimer);
-          this.connectTimer = null;
-        }
-        if (this.connectResolve) {
-          this.connectResolve(address);
-          this.connectResolve = null;
-          this.connectReject = null;
-        }
-        this.onConnected?.(address);
-        this.json(res, {status: "ok"});
-      });
+      void this.readJson(req)
+        .then(body => {
+          const address = (body?.address ?? "") as Address;
+          this.connectedAddress = address;
+          if (this.connectTimer) {
+            clearTimeout(this.connectTimer);
+            this.connectTimer = null;
+          }
+          if (this.connectResolve) {
+            this.connectResolve(address);
+            this.connectResolve = null;
+            this.connectReject = null;
+          }
+          this.onConnected?.(address);
+          this.json(res, {status: "ok"});
+        })
+        .catch(err => this.handleJsonReadError(res, err));
       return;
     }
 
@@ -578,10 +604,12 @@ export class BrowserWalletBridge {
     }
 
     if (path === "/api/result" && req.method === "POST") {
-      void this.readJson(req).then(body => {
-        this.handleResult(body);
-        this.json(res, {status: "ok"});
-      });
+      void this.readJson(req)
+        .then(body => {
+          this.handleResult(body);
+          this.json(res, {status: "ok"});
+        })
+        .catch(err => this.handleJsonReadError(res, err));
       return;
     }
 
@@ -637,8 +665,27 @@ export class BrowserWalletBridge {
     const idx = this.txQueue.indexOf(pending);
     if (idx >= 0) this.txQueue.splice(idx, 1);
     if (pending.timer) clearTimeout(pending.timer);
-    pending.from = body?.from as Address | undefined;
+    pending.from = typeof body?.from === "string" && body.from ? (body.from as Address) : undefined;
     if (pending.from) this.lastResultFrom.set(id, pending.from);
+
+    const expectedSigner = pending.expectedSigner ?? this.connectedAddress ?? undefined;
+    if (pending.from && expectedSigner && !sameAddress(pending.from, expectedSigner)) {
+      pending.reject(
+        new Error(
+          `Wallet returned a result from ${pending.from}, but the expected signer is ${expectedSigner}. ` +
+            "Switch back to the expected account or reconnect the wallet session.",
+        ),
+      );
+      return;
+    }
+    if (pending.from && !expectedSigner) {
+      pending.reject(
+        new Error(
+          `Wallet returned a result from ${pending.from}, but no connected signer was recorded for this session.`,
+        ),
+      );
+      return;
+    }
 
     if (body?.status === "sent" && body?.txHash) {
       pending.resolve(body.txHash as Hash);
@@ -681,11 +728,52 @@ export class BrowserWalletBridge {
     res.end(JSON.stringify(payload));
   }
 
+  private isValidHost(host: string | undefined): boolean {
+    // Validate against the port captured at start() rather than the live
+    // server address: a long-poll flushed during teardown is handled after the
+    // server has closed (address() → null), and must still pass the check.
+    const port = this.boundPort;
+    return host === `127.0.0.1:${port}` || host === `localhost:${port}`;
+  }
+
+  private isValidToken(header: string | string[] | undefined): boolean {
+    if (typeof header !== "string") return false;
+    const received = Buffer.from(header);
+    const expected = Buffer.from(this.token);
+    return received.length === expected.length && timingSafeEqual(received, expected);
+  }
+
+  private handleJsonReadError(res: http.ServerResponse, err: unknown): void {
+    if (err instanceof PayloadTooLargeError) {
+      res.statusCode = 413;
+      res.end("Payload too large");
+      return;
+    }
+    res.statusCode = 400;
+    this.json(res, {error: "bad request"});
+  }
+
   private readJson(req: http.IncomingMessage): Promise<any> {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       const chunks: Buffer[] = [];
-      req.on("data", c => chunks.push(c as Buffer));
+      let total = 0;
+      let settled = false;
+      req.on("data", c => {
+        if (settled) return;
+        const chunk = c as Buffer;
+        total += chunk.length;
+        if (total > MAX_JSON_BODY_BYTES) {
+          settled = true;
+          chunks.length = 0;
+          reject(new PayloadTooLargeError());
+          req.resume();
+          return;
+        }
+        chunks.push(chunk);
+      });
       req.on("end", () => {
+        if (settled) return;
+        settled = true;
         try {
           const raw = Buffer.concat(chunks).toString("utf-8");
           resolve(raw ? JSON.parse(raw) : {});
@@ -693,7 +781,11 @@ export class BrowserWalletBridge {
           resolve({});
         }
       });
-      req.on("error", () => resolve({}));
+      req.on("error", () => {
+        if (settled) return;
+        settled = true;
+        resolve({});
+      });
     });
   }
 }

--- a/src/lib/wallet/browserSend.ts
+++ b/src/lib/wallet/browserSend.ts
@@ -45,6 +45,11 @@ export interface Eip1193Provider {
   request(args: {method: string; params?: any[]}): Promise<any>;
 }
 
+export interface BridgeSendResult {
+  txHash: Hash;
+  from?: Address;
+}
+
 /**
  * Transport seam between "how a tx gets to the wallet" and everything above it
  * (preflight, receipt wait, EIP-1193 shim, labels). A local transport owns a
@@ -53,7 +58,7 @@ export interface Eip1193Provider {
 export interface BridgeTransport {
   readonly kind: "local" | "remote";
   readonly signerAddress: Address;
-  sendTransaction(tx: Omit<BridgeTxRequest, "id">): Promise<Hash>;
+  sendTransaction(tx: Omit<BridgeTxRequest, "id">): Promise<BridgeSendResult>;
   /** Local: close the bridge. Remote: no-op (detach only — never kill a shared session). */
   close(finalMessage?: string): Promise<void>;
 }
@@ -105,6 +110,20 @@ export function buildBridgeChain(chain: GenLayerChain, rpcUrl: string): BridgeCh
   };
 }
 
+function sameAddress(a: Address, b: Address): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function assertResultSigner(result: BridgeSendResult, signerAddress: Address): Hash {
+  if (result.from && !sameAddress(result.from, signerAddress)) {
+    throw new Error(
+      `Wallet returned a transaction from ${result.from}, but the expected signer is ${signerAddress}. ` +
+        "Switch back to the expected account or reconnect the wallet session.",
+    );
+  }
+  return result.txHash;
+}
+
 /**
  * Build the shared signing lanes (preflight + receipt wait Lane A, EIP-1193
  * shim Lane B, labels) on top of a transport. This body is identical for local
@@ -152,13 +171,14 @@ export function buildBrowserSession(
       );
     }
 
-    const hash = await transport.sendTransaction({
+    const result = await transport.sendTransaction({
       to: tx.to,
       data: tx.data,
       value: tx.value,
       gas: tx.gas,
       label: tx.label,
     });
+    const hash = assertResultSigner(result, signerAddress);
 
     const receipt = await publicClient.waitForTransactionReceipt({
       hash,
@@ -194,7 +214,7 @@ export function buildBrowserSession(
             nonce?: string;
             type?: string;
           };
-          const hash = await transport.sendTransaction({
+          const result = await transport.sendTransaction({
             to: req.to as Address,
             data: (req.data ?? "0x") as `0x${string}`,
             value: req.value !== undefined ? hexToBigInt(req.value as `0x${string}`) : undefined,
@@ -204,6 +224,7 @@ export function buildBrowserSession(
             type: req.type,
             label: nextLabel ?? "GenLayer transaction",
           });
+          const hash = assertResultSigner(result, signerAddress);
           nextLabel = undefined;
           return hash;
         }
@@ -238,8 +259,8 @@ class LocalBridgeTransport implements BridgeTransport {
     private readonly bridge: BrowserWalletBridge,
     readonly signerAddress: Address,
   ) {}
-  sendTransaction(tx: Omit<BridgeTxRequest, "id">): Promise<Hash> {
-    return this.bridge.sendTransaction(tx);
+  async sendTransaction(tx: Omit<BridgeTxRequest, "id">): Promise<BridgeSendResult> {
+    return {txHash: await this.bridge.sendTransaction(tx)};
   }
   close(finalMessage?: string): Promise<void> {
     return this.bridge.close(finalMessage);
@@ -253,7 +274,7 @@ class RemoteSessionTransport implements BridgeTransport {
     private readonly client: WalletSessionClient,
     readonly signerAddress: Address,
   ) {}
-  async sendTransaction(tx: Omit<BridgeTxRequest, "id">): Promise<Hash> {
+  async sendTransaction(tx: Omit<BridgeTxRequest, "id">): Promise<BridgeSendResult> {
     const id = await this.client.enqueueTx(tx);
     return this.client.waitForTxResult(id);
   }
@@ -284,7 +305,10 @@ export async function openBrowserWalletSession(params: BrowserSessionParams): Pr
 
   const {url} = await bridge.start();
   logInfo(`Open this URL in a browser with your wallet to sign:\n  ${url}`);
-  logInfo("(Remote/SSH? Forward the port first: ssh -L <port>:127.0.0.1:<port> ...)");
+  logInfo(
+    "(Remote/SSH? Forward the port first: ssh -L <port>:127.0.0.1:<port> ...; " +
+      "do not use -g, GatewayPorts yes, or bind the local side to a public interface.)",
+  );
 
   const signerAddress = await bridge.waitForConnection();
   const transport = new LocalBridgeTransport(bridge, signerAddress);

--- a/src/lib/wallet/sessionClient.ts
+++ b/src/lib/wallet/sessionClient.ts
@@ -16,6 +16,11 @@ export interface SessionState {
   createdAt: number;
 }
 
+export interface SessionTxResult {
+  txHash: Hash;
+  from?: Address;
+}
+
 type FetchFn = typeof fetch;
 
 /**
@@ -92,7 +97,7 @@ export class WalletSessionClient {
    * Poll for a tx result. Fails fast if the page heartbeat goes stale (tab
    * closed) rather than blocking for the full timeout.
    */
-  async waitForTxResult(id: string, timeoutMs = TX_TIMEOUT_MS): Promise<Hash> {
+  async waitForTxResult(id: string, timeoutMs = TX_TIMEOUT_MS): Promise<SessionTxResult> {
     const deadline = Date.now() + timeoutMs;
     for (;;) {
       const res = await this.fetchFn(`${this.base}/api/tx?id=${encodeURIComponent(id)}`, {
@@ -101,7 +106,12 @@ export class WalletSessionClient {
       if (res.ok) {
         const rec: any = await res.json();
         if (rec.state === "done") {
-          if (rec.status === "sent" && rec.txHash) return rec.txHash as Hash;
+          if (rec.status === "sent" && rec.txHash) {
+            return {
+              txHash: rec.txHash as Hash,
+              from: typeof rec.from === "string" ? (rec.from as Address) : undefined,
+            };
+          }
           if (rec.status === "rejected") throw new Error("Transaction rejected in wallet");
           throw new Error(rec.message || "Transaction failed in wallet");
         }

--- a/tests/libs/browserBridge.test.ts
+++ b/tests/libs/browserBridge.test.ts
@@ -1,5 +1,27 @@
 import {describe, test, expect, vi, beforeEach, afterEach} from "vitest";
+import http from "node:http";
 import {BrowserWalletBridge, type BridgeChainParams} from "../../src/lib/wallet/browserBridge";
+
+/**
+ * Raw HTTP GET that lets us set an arbitrary Host header. undici's `fetch`
+ * ignores a caller-supplied Host (it derives it from the URL), so the
+ * Host-validation guard can only be exercised through node:http.
+ */
+function rawGet(
+  port: number,
+  path: string,
+  headers: Record<string, string>,
+): Promise<{status: number; body: string}> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({host: "127.0.0.1", port, path, method: "GET", headers}, res => {
+      let body = "";
+      res.on("data", c => (body += c));
+      res.on("end", () => resolve({status: res.statusCode ?? 0, body}));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
 
 const CHAIN: BridgeChainParams = {
   chainId: 4221,
@@ -86,6 +108,18 @@ describe("BrowserWalletBridge", () => {
     expect(badToken.status).toBe(403);
   });
 
+  test("rejects a request with a non-loopback Host header (403), accepts loopback", async () => {
+    const port = Number(new URL(origin).port);
+    const bad = await rawGet(port, "/api/session", {Host: "evil.example", "X-Bridge-Token": token});
+    expect(bad.status).toBe(403);
+    expect(bad.body).toMatch(/bad host/i);
+    // Sanity: the same request with the correct loopback Host is served.
+    const ok = await rawGet(port, "/api/session", {Host: `127.0.0.1:${port}`, "X-Bridge-Token": token});
+    expect(ok.status).toBe(200);
+    const okLocalhost = await rawGet(port, "/api/session", {Host: `localhost:${port}`, "X-Bridge-Token": token});
+    expect(okLocalhost.status).toBe(200);
+  });
+
   test("rejects a POST with a wrong Origin header (403)", async () => {
     const res = await fetch(`${origin}/api/connected`, {
       method: "POST",
@@ -122,6 +156,27 @@ describe("BrowserWalletBridge", () => {
 
     await authPost("/api/result", {id: next.tx.id, status: "sent", txHash: "0xhash", from: ADDRESS});
     await expect(sendPromise).resolves.toBe("0xhash");
+  });
+
+  test("rejects a result whose `from` differs from the connected signer (account switch)", async () => {
+    await authPost("/api/connected", {address: ADDRESS});
+    await bridge.waitForConnection();
+
+    const sendPromise = bridge.sendTransaction({
+      to: "0xStaking00000000000000000000000000000000" as `0x${string}`,
+      data: "0xabcdef" as `0x${string}`,
+      value: 100n,
+      label: "Join as validator",
+    });
+    // Attach the rejection expectation before delivering the mismatched result
+    // so the rejection is never momentarily unhandled.
+    const assertion = expect(sendPromise).rejects.toThrow(/expected signer/i);
+
+    const next = await (await authGet("/api/next")).json();
+    const OTHER = "0xOtherAccount00000000000000000000000000000" as `0x${string}`;
+    // Wallet switched accounts mid-flight and returned a result from OTHER.
+    await authPost("/api/result", {id: next.tx.id, status: "sent", txHash: "0xhash", from: OTHER});
+    await assertion;
   });
 
   test("serializes gas/type/nonce pass-through as hex quantities when present", async () => {

--- a/tests/libs/configFileManager.test.ts
+++ b/tests/libs/configFileManager.test.ts
@@ -35,10 +35,13 @@ describe("ConfigFileManager", () => {
     new ConfigFileManager();
 
     expect(fs.existsSync).toHaveBeenCalledWith(mockFolderPath);
-    expect(fs.mkdirSync).toHaveBeenCalledWith(mockFolderPath, { recursive: true });
+    // Config dir and keystores dir are created private (0o700) to protect keystores.
+    expect(fs.mkdirSync).toHaveBeenCalledWith(mockFolderPath, { recursive: true, mode: 0o700 });
+    expect(fs.chmodSync).toHaveBeenCalledWith(mockFolderPath, 0o700);
 
     expect(fs.existsSync).toHaveBeenCalledWith(mockKeystoresPath);
-    expect(fs.mkdirSync).toHaveBeenCalledWith(mockKeystoresPath, { recursive: true });
+    expect(fs.mkdirSync).toHaveBeenCalledWith(mockKeystoresPath, { recursive: true, mode: 0o700 });
+    expect(fs.chmodSync).toHaveBeenCalledWith(mockKeystoresPath, 0o700);
 
     expect(fs.existsSync).toHaveBeenCalledWith(mockConfigFilePath);
     expect(fs.writeFileSync).toHaveBeenCalledWith(mockConfigFilePath, JSON.stringify({}, null, 2));

--- a/tests/libs/sessionClient.test.ts
+++ b/tests/libs/sessionClient.test.ts
@@ -109,7 +109,9 @@ describe("WalletSessionClient", () => {
     const client = new WalletSessionClient(descriptor, {pollIntervalMs: 20});
     await client.waitForConnection(3000);
     const id = await client.enqueueTx({to: "0xTo" as any, data: "0x01", value: 100n, label: "L"});
-    await expect(client.waitForTxResult(id, 3000)).resolves.toBe("0xdeadbeef");
+    // waitForTxResult now surfaces the signer (`from`) alongside the hash so the
+    // caller can verify the result came from the connected account.
+    await expect(client.waitForTxResult(id, 3000)).resolves.toEqual({txHash: "0xdeadbeef", from: ADDRESS});
   });
 
   test("waitForTxResult throws on a rejected tx", async () => {


### PR DESCRIPTION
## Summary

Targeted hardening of the browser-wallet signing bridge per a security review. The bridge is otherwise sound — this keeps all existing behavior and tests intact and only closes the flagged gaps. Existing no-CORS, origin-fail-closed, and token-on-every-route checks are unchanged.

## Changes

- **MEDIUM — Verify signer + handle account switch.** Reject a wallet result whose `from` differs from the connected/expected signer, both in the bridge (`browserBridge.ts` `handleResult`) and in `browserSend.ts` (`assertResultSigner`); `from` is plumbed through `sessionClient.ts` `waitForTxResult`. On `accountsChanged`, the page re-POSTs `/api/connected` so the daemon stays coherent (aborts on disconnect), and the misleading "The CLI will verify the sender" copy now matches the enforced behavior.
- **LOW — Constant-time token compare.** Length-guarded `crypto.timingSafeEqual`.
- **LOW — Host-header validation.** Reject `Host` != `127.0.0.1:<port>` / `localhost:<port>` with 403 before route dispatch. Validated against the port captured at `start()` so a long-poll flushed during teardown still passes.
- **LOW — `~/.genlayer` perms.** Config + keystores dirs created `{recursive:true, mode:0o700}` and `chmodSync(dir, 0o700)`.
- **LOW — Scrub token from URL.** `history.replaceState` after reading the hash token.
- **LOW — Body cap.** Abort request bodies past 64KB with 413.
- **Doc.** Warn against `ssh -g` / `GatewayPorts yes` / binding a public interface where port-forwarding is suggested.

## Tests

- New: mismatched-`from` result is rejected with a clear signer-mismatch error (account-switch case).
- New: non-loopback `Host` header is rejected (403) while loopback (`127.0.0.1` / `localhost`) is served.
- Updated existing `configFileManager` and `sessionClient` tests for the 0700 perms and the `waitForTxResult` `{txHash, from}` shape.

## Verification

- `npm run build` clean.
- `npx vitest run` → 749 passed (72 files); +2 new hardening tests.
- `tsc --noEmit` → 32 errors, identical to the pre-existing baseline (zero new; none in touched files).
- No version bump.