### PR TITLE
feat(staking): wizard guides identity on the vesting funding path

### DIFF
--- a/src/commands/staking/wizard.ts
+++ b/src/commands/staking/wizard.ts
@@ -1297,29 +1297,33 @@ export class ValidatorWizardAction extends StakingAction {
     }
   }
 
+  /**
+   * How the user can set identity later — differs by funding source. A
+   * vesting-backed validator's identity is set through the vesting contract
+   * (`vesting validator set-identity`), a wallet-backed one through staking.
+   */
+  private identitySetLaterHint(state: Partial<WizardState>): string {
+    if (state.stakeSource === "vesting") {
+      const walletHint = state.validatorWalletAddress || "<validator-wallet>";
+      return `genlayer vesting validator set-identity ${walletHint} --vesting ${state.vestingContract}`;
+    }
+    return "genlayer staking set-identity";
+  }
+
   private async stepIdentitySetup(state: Partial<WizardState>, options: WizardOptions): Promise<void> {
     console.log("Step 7: Identity Setup");
     console.log("----------------------\n");
 
-    // Setting identity on a vesting-backed validator wallet goes through the
-    // vesting contract (a different call than staking's setIdentity). Rather than
-    // fork the whole identity step, point the user at the dedicated command.
-    if (state.stakeSource === "vesting") {
-      const walletHint = state.validatorWalletAddress || "<validator-wallet>";
-      console.log("Identity setup is skipped for vesting-backed validators in the wizard.");
-      console.log(
-        `Set it later with: genlayer vesting validator set-identity ${walletHint} ` +
-          `--vesting ${state.vestingContract} --moniker "<name>"\n`,
-      );
-      return;
-    }
+    // Both funding sources run the same guided identity step: identical prompts
+    // and fields. Only the commit target differs — a vesting-backed validator's
+    // identity is set through the vesting contract (see commitIdentity).
 
     if (this.ni) {
       // Identity is optional non-interactively: driven by --moniker. No moniker
       // means "skip identity" (same as the interactive "no" answer).
       if (!options.moniker) {
         console.log("\nNo --moniker given; skipping identity setup.");
-        console.log("You can set it later with: genlayer staking set-identity\n");
+        console.log(`You can set it later with: ${this.identitySetLaterHint(state)}\n`);
         return;
       }
       state.identity = {
@@ -1346,7 +1350,7 @@ export class ValidatorWizardAction extends StakingAction {
     ]);
 
     if (!setupIdentity) {
-      console.log("\nYou can set up identity later with: genlayer staking set-identity\n");
+      console.log(`\nYou can set up identity later with: ${this.identitySetLaterHint(state)}\n`);
       return;
     }
 
@@ -1431,20 +1435,36 @@ export class ValidatorWizardAction extends StakingAction {
   }
 
   /**
-   * Send the set-identity transaction from `state.identity` — via the browser
-   * bridge for a browser owner, otherwise the keystore staking client. Shared by
-   * the interactive and non-interactive identity steps so both behave identically.
+   * Send the set-identity transaction from `state.identity`. Routing:
+   *  - vesting funding → the vesting contract's vestingValidatorSetIdentity
+   *    (keystore via the SDK client, browser via the shared bridge);
+   *  - wallet funding → staking's setIdentity (keystore) / buildSetIdentityTx
+   *    (browser), unchanged.
+   * Shared by the interactive and non-interactive identity steps so both behave
+   * identically. A revert (e.g. consensus gaps) is caught: the wizard warns and
+   * continues to the summary rather than crashing or losing the created validator.
    */
   private async commitIdentity(state: Partial<WizardState>, options: WizardOptions): Promise<void> {
     const identity = state.identity!;
 
-    this.startSpinner("Setting validator identity...");
-
-    // Use the validator wallet address (contract), not owner address
+    // Use the validator wallet address (contract), not the owner address.
     const validatorAddress = ensureHexPrefix(state.validatorWalletAddress || state.accountAddress!);
 
+    // Vesting identity must target the just-created vesting validator wallet. If
+    // we never learned that address (owner ≠ wallet), don't send a doomed tx —
+    // point the user at the standalone command instead.
+    if (state.stakeSource === "vesting" && !state.validatorWalletAddress) {
+      this.logWarning("Could not determine the vesting validator wallet address; skipping identity.");
+      console.log(`You can set it later with: ${this.identitySetLaterHint(state)}\n`);
+      return;
+    }
+
+    this.startSpinner("Setting validator identity...");
+
     try {
-      if (state.ownerIsBrowserWallet) {
+      if (state.stakeSource === "vesting") {
+        await this.commitVestingIdentity(state, options, validatorAddress);
+      } else if (state.ownerIsBrowserWallet) {
         const session = await this.ensureBrowserSession(state, options);
         this.setSpinnerText("Confirm the identity transaction in your browser wallet...");
         const {to, data} = buildSetIdentityTx(validatorAddress, {
@@ -1483,8 +1503,66 @@ export class ValidatorWizardAction extends StakingAction {
     } catch (error: any) {
       this.stopSpinner();
       this.logWarning(`Failed to set identity: ${error.message || error}`);
-      console.log("You can try again later with: genlayer staking set-identity\n");
+      console.log(`You can try again later with: ${this.identitySetLaterHint(state)}\n`);
     }
+  }
+
+  /**
+   * Set the identity of a vesting-backed validator wallet through the vesting
+   * contract. Keystore owner → the SDK's vestingValidatorSetIdentity (same method
+   * `vesting validator set-identity` calls); browser owner → the same calldata
+   * builder used by that command, sent through the shared wizard session. The
+   * wizard has no extraCid field, so it is sent empty ("0x").
+   */
+  private async commitVestingIdentity(
+    state: Partial<WizardState>,
+    options: WizardOptions,
+    validatorAddress: string,
+  ): Promise<void> {
+    const identity = state.identity!;
+    const vesting = state.vestingContract as Address;
+
+    if (state.ownerIsBrowserWallet) {
+      const session = await this.ensureBrowserSession(state, options);
+      this.setSpinnerText("Confirm the identity transaction in your browser wallet...");
+      const {to, data} = buildTx(abi.VESTING_ABI as any, vesting, "vestingValidatorSetIdentity", [
+        validatorAddress,
+        identity.moniker,
+        identity.logoUri || "",
+        identity.website || "",
+        identity.description || "",
+        identity.email || "",
+        identity.twitter || "",
+        identity.telegram || "",
+        identity.github || "",
+        "0x",
+      ]);
+      await session.sendTransaction({to, data, label: `Set validator identity (${identity.moniker})`});
+      return;
+    }
+
+    // The genlayer-js client the keystore path builds exposes the vesting actions
+    // at runtime; the cast bridges the CLI-facing type shim (same pattern as the
+    // vesting join step).
+    const client = (await this.getStakingClient({
+      ...options,
+      account: state.accountName,
+      network: state.networkAlias,
+    })) as unknown as VestingClient;
+
+    await client.vestingValidatorSetIdentity({
+      vesting,
+      wallet: validatorAddress as Address,
+      moniker: identity.moniker,
+      logoUri: identity.logoUri || "",
+      website: identity.website || "",
+      description: identity.description || "",
+      email: identity.email || "",
+      twitter: identity.twitter || "",
+      telegram: identity.telegram || "",
+      github: identity.github || "",
+      extraCid: "0x",
+    });
   }
 
   private showSummary(state: WizardState): void {

--- a/tests/actions/stakingWizard.test.ts
+++ b/tests/actions/stakingWizard.test.ts
@@ -183,14 +183,15 @@ describe("ValidatorWizardAction --wallet browser (owner)", () => {
     // funding source -> vesting (one contract, no pick prompt)
     // step4 useOperator -> true; operatorChoice -> existing; operatorAddress
     // step5 stakeAmount -> "42gen"; confirm -> true
-    // (identity is skipped for vesting-backed validators)
+    // step7 setupIdentity -> false (this test focuses on join)
     vi.mocked(inquirer.prompt)
       .mockResolvedValueOnce({stakeSource: "vesting"})
       .mockResolvedValueOnce({useOperator: true})
       .mockResolvedValueOnce({operatorChoice: "existing"})
       .mockResolvedValueOnce({operatorAddress: "0xOperatorAddr"})
       .mockResolvedValueOnce({stakeAmount: "42gen"})
-      .mockResolvedValueOnce({confirm: true});
+      .mockResolvedValueOnce({confirm: true})
+      .mockResolvedValueOnce({setupIdentity: false});
 
     vi.spyOn(action as any, "listAccounts").mockReturnValue([]);
 
@@ -222,6 +223,53 @@ describe("ValidatorWizardAction --wallet browser (owner)", () => {
     );
   });
 
+  test("vesting source: browser owner sets identity via vestingValidatorSetIdentity through the same session", async () => {
+    mockGlClient.getBeneficiaryVestings.mockResolvedValue(["0xVesting"]);
+
+    vi.mocked(inquirer.prompt)
+      .mockResolvedValueOnce({stakeSource: "vesting"})
+      .mockResolvedValueOnce({useOperator: true})
+      .mockResolvedValueOnce({operatorChoice: "existing"})
+      .mockResolvedValueOnce({operatorAddress: "0xOperatorAddr"})
+      .mockResolvedValueOnce({stakeAmount: "42gen"})
+      .mockResolvedValueOnce({confirm: true})
+      // step7: guided identity (browser owner, vesting-backed)
+      .mockResolvedValueOnce({setupIdentity: true})
+      .mockResolvedValueOnce({moniker: "MyVesting"})
+      .mockResolvedValueOnce({logoUri: ""})
+      .mockResolvedValueOnce({website: ""})
+      .mockResolvedValueOnce({description: ""})
+      .mockResolvedValueOnce({email: ""})
+      .mockResolvedValueOnce({twitter: ""})
+      .mockResolvedValueOnce({telegram: ""})
+      .mockResolvedValueOnce({github: ""});
+
+    vi.spyOn(action as any, "listAccounts").mockReturnValue([]);
+
+    await action.execute({amount: "", wallet: "browser", network: "testnet-bradbury"} as any);
+
+    // Identity calldata built for vestingValidatorSetIdentity against the created
+    // wallet (0xVWallet from getValidatorWallets), extraCid empty.
+    expect(vi.mocked(buildTx)).toHaveBeenCalledWith([], "0xVesting", "vestingValidatorSetIdentity", [
+      "0xVWallet",
+      "MyVesting",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "0x",
+    ]);
+    // Sent through the SAME browser session used for the join, never the keystore.
+    expect(sendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({label: expect.stringContaining("Set validator identity")}),
+    );
+    expect(getStakingClientSpy).not.toHaveBeenCalled();
+    expect(action["succeedSpinner"]).toHaveBeenCalledWith("Validator identity set!");
+  });
+
   test("keystore path is untouched: --account + --wallet browser is rejected up-front", async () => {
     await expect(action.execute({amount: "", wallet: "browser", account: "owner"} as any)).rejects.toThrow(
       /--account cannot be used with --wallet browser/,
@@ -234,6 +282,7 @@ describe("ValidatorWizardAction stake source (keystore owner)", () => {
   let action: ValidatorWizardAction;
   let validatorJoin: ReturnType<typeof vi.fn>;
   let vestingValidatorJoin: ReturnType<typeof vi.fn>;
+  let vestingValidatorSetIdentity: ReturnType<typeof vi.fn>;
   let getStakingClientSpy: any;
   let getBrowserWalletSessionSpy: any;
 
@@ -287,9 +336,15 @@ describe("ValidatorWizardAction stake source (keystore owner)", () => {
       blockNumber: 12n,
       gasUsed: 100n,
     });
+    vestingValidatorSetIdentity = vi.fn().mockResolvedValue({
+      transactionHash: "0xVIdTx",
+      blockNumber: 13n,
+      gasUsed: 100n,
+    });
     getStakingClientSpy = vi.spyOn(action as any, "getStakingClient").mockResolvedValue({
       validatorJoin,
       vestingValidatorJoin,
+      vestingValidatorSetIdentity,
       getValidatorWallets: vi.fn().mockResolvedValue(["0xVWalletCreated"]),
     } as any);
 
@@ -337,7 +392,8 @@ describe("ValidatorWizardAction stake source (keystore owner)", () => {
       .mockResolvedValueOnce({operatorChoice: "existing"})
       .mockResolvedValueOnce({operatorAddress: "0xOperatorAddr"})
       .mockResolvedValueOnce({stakeAmount: "42gen"})
-      .mockResolvedValueOnce({confirm: true});
+      .mockResolvedValueOnce({confirm: true})
+      .mockResolvedValueOnce({setupIdentity: false}); // step7 (this test focuses on join)
 
     await run();
 
@@ -379,7 +435,8 @@ describe("ValidatorWizardAction stake source (keystore owner)", () => {
       .mockResolvedValueOnce({selectedVesting: "0xV2"})
       .mockResolvedValueOnce({useOperator: false})
       .mockResolvedValueOnce({stakeAmount: "42gen"})
-      .mockResolvedValueOnce({confirm: true});
+      .mockResolvedValueOnce({confirm: true})
+      .mockResolvedValueOnce({setupIdentity: false}); // step7 (this test focuses on join)
 
     await run();
 
@@ -414,6 +471,89 @@ describe("ValidatorWizardAction stake source (keystore owner)", () => {
     expect(vestingValidatorJoin).not.toHaveBeenCalled();
     expect(validatorJoin).not.toHaveBeenCalled();
   });
+
+  test("(g) vesting source: guided identity routes through vestingValidatorSetIdentity", async () => {
+    mockGlClient.getBeneficiaryVestings.mockResolvedValue(["0xVesting"]);
+    vi.mocked(inquirer.prompt)
+      .mockResolvedValueOnce({stakeSource: "vesting"})
+      .mockResolvedValueOnce({useOperator: false})
+      .mockResolvedValueOnce({stakeAmount: "42gen"})
+      .mockResolvedValueOnce({confirm: true})
+      // step7: same guided prompts as the wallet path
+      .mockResolvedValueOnce({setupIdentity: true})
+      .mockResolvedValueOnce({moniker: "MyVesting"})
+      .mockResolvedValueOnce({logoUri: ""})
+      .mockResolvedValueOnce({website: "https://v.io"})
+      .mockResolvedValueOnce({description: ""})
+      .mockResolvedValueOnce({email: ""})
+      .mockResolvedValueOnce({twitter: ""})
+      .mockResolvedValueOnce({telegram: ""})
+      .mockResolvedValueOnce({github: ""});
+
+    await run();
+
+    // Identity was set through the vesting contract, targeting the created wallet
+    // — NOT staking's setIdentity (there is no such raw-viem bypass).
+    expect(vestingValidatorSetIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vesting: "0xVesting",
+        wallet: "0xVWalletCreated",
+        moniker: "MyVesting",
+        website: "https://v.io",
+        extraCid: "0x",
+      }),
+    );
+    expect(action["succeedSpinner"]).toHaveBeenCalledWith("Validator identity set!");
+  });
+
+  test("(h) vesting identity revert is caught: wizard warns and still reaches the summary", async () => {
+    mockGlClient.getBeneficiaryVestings.mockResolvedValue(["0xVesting"]);
+    vestingValidatorSetIdentity.mockRejectedValueOnce(new Error("consensus gap"));
+    vi.mocked(inquirer.prompt)
+      .mockResolvedValueOnce({stakeSource: "vesting"})
+      .mockResolvedValueOnce({useOperator: false})
+      .mockResolvedValueOnce({stakeAmount: "42gen"})
+      .mockResolvedValueOnce({confirm: true})
+      .mockResolvedValueOnce({setupIdentity: true})
+      .mockResolvedValueOnce({moniker: "MyVesting"})
+      .mockResolvedValueOnce({logoUri: ""})
+      .mockResolvedValueOnce({website: ""})
+      .mockResolvedValueOnce({description: ""})
+      .mockResolvedValueOnce({email: ""})
+      .mockResolvedValueOnce({twitter: ""})
+      .mockResolvedValueOnce({telegram: ""})
+      .mockResolvedValueOnce({github: ""});
+
+    await run();
+
+    // Join succeeded, identity reverted → warn (not crash). The wizard does not
+    // hit its top-level failure path, so execute() returns and the summary runs.
+    expect(vestingValidatorJoin).toHaveBeenCalledOnce();
+    expect(action["succeedSpinner"]).toHaveBeenCalledWith(
+      "Vesting-backed validator created successfully!",
+      expect.objectContaining({validatorWallet: "0xVWalletCreated"}),
+    );
+    expect(action["logWarning"]).toHaveBeenCalledWith(expect.stringMatching(/Failed to set identity.*consensus gap/));
+    expect(action["failSpinner"]).not.toHaveBeenCalled();
+  });
+
+  test("(i) --skip-identity is respected on the vesting path", async () => {
+    mockGlClient.getBeneficiaryVestings.mockResolvedValue(["0xVesting"]);
+    vi.mocked(inquirer.prompt)
+      .mockResolvedValueOnce({stakeSource: "vesting"})
+      .mockResolvedValueOnce({useOperator: false})
+      .mockResolvedValueOnce({stakeAmount: "42gen"})
+      .mockResolvedValueOnce({confirm: true});
+
+    await run({skipIdentity: true});
+
+    expect(vestingValidatorJoin).toHaveBeenCalledOnce();
+    expect(vestingValidatorSetIdentity).not.toHaveBeenCalled();
+    // No identity prompt was ever shown (last prompt was the stake confirm).
+    const promptCalls = vi.mocked(inquirer.prompt).mock.calls;
+    const askedIdentity = promptCalls.some((c: any) => c[0]?.[0]?.name === "setupIdentity");
+    expect(askedIdentity).toBe(false);
+  });
 });
 
 describe("ValidatorWizardAction --non-interactive (keystore owner)", () => {
@@ -421,6 +561,7 @@ describe("ValidatorWizardAction --non-interactive (keystore owner)", () => {
   let validatorJoin: ReturnType<typeof vi.fn>;
   let vestingValidatorJoin: ReturnType<typeof vi.fn>;
   let setIdentity: ReturnType<typeof vi.fn>;
+  let vestingValidatorSetIdentity: ReturnType<typeof vi.fn>;
   let getStakingClientSpy: any;
   let getBrowserWalletSessionSpy: any;
 
@@ -471,10 +612,16 @@ describe("ValidatorWizardAction --non-interactive (keystore owner)", () => {
       blockNumber: 12n,
     });
     setIdentity = vi.fn().mockResolvedValue({transactionHash: "0xIdTx"});
+    vestingValidatorSetIdentity = vi.fn().mockResolvedValue({
+      transactionHash: "0xVIdTx",
+      blockNumber: 13n,
+      gasUsed: 100n,
+    });
     getStakingClientSpy = vi.spyOn(action as any, "getStakingClient").mockResolvedValue({
       validatorJoin,
       vestingValidatorJoin,
       setIdentity,
+      vestingValidatorSetIdentity,
       getValidatorWallets: vi.fn().mockResolvedValue(["0xVWalletCreated"]),
     } as any);
 
@@ -575,6 +722,40 @@ describe("ValidatorWizardAction --non-interactive (keystore owner)", () => {
       operator: "0xOwner",
       amount: 50n * 10n ** 18n,
     });
+  });
+
+  test("vesting source + --moniker: identity set from flags via vestingValidatorSetIdentity, zero prompts", async () => {
+    await run({
+      fundingSource: "vesting",
+      vestingContract: "0xVesting",
+      operator: EXTERNAL_OP,
+      amount: "50gen",
+      moniker: "NIVesting",
+      website: "https://ni.io",
+    });
+
+    expect(inquirer.prompt).not.toHaveBeenCalled();
+    expect(vestingValidatorJoin).toHaveBeenCalledOnce();
+    // Identity applied through the vesting contract against the created wallet.
+    expect(vestingValidatorSetIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vesting: "0xVesting",
+        wallet: "0xVWalletCreated",
+        moniker: "NIVesting",
+        website: "https://ni.io",
+        extraCid: "0x",
+      }),
+    );
+    // The wallet-path setIdentity is never used for a vesting-backed validator.
+    expect(setIdentity).not.toHaveBeenCalled();
+  });
+
+  test("vesting source without --moniker: identity skipped, still zero prompts", async () => {
+    await run({fundingSource: "vesting", vestingContract: "0xVesting", operatorSame: true, amount: "50gen"});
+
+    expect(inquirer.prompt).not.toHaveBeenCalled();
+    expect(vestingValidatorJoin).toHaveBeenCalledOnce();
+    expect(vestingValidatorSetIdentity).not.toHaveBeenCalled();
   });
 
   test("missing --amount fails clearly naming the flag", async () => {


### PR DESCRIPTION
## What

The `staking wizard` previously **skipped** the identity step when funding a validator from a vesting contract — it only printed a pointer to `genlayer vesting validator set-identity`. It now **guides the user through identity on the vesting path too**, with the same prompts/fields as the wallet path, and actually sets it — routed through the SDK (no raw-viem bypass).

## Changes

- **`src/commands/staking/wizard.ts`**
  - `stepIdentitySetup`: removed the vesting early-skip. Both funding sources now run the identical guided identity step (moniker / logo-uri / website / description / email / twitter / telegram / github), interactive **and** non-interactive.
  - `commitIdentity`: routes by funding source. Vesting → new `commitVestingIdentity`; wallet path unchanged.
  - `commitVestingIdentity`: sets identity through the vesting contract targeting the just-created vesting-backed validator wallet:
    - **keystore owner** → the SDK's `client.vestingValidatorSetIdentity({ vesting, wallet, ... })` (the same method the standalone `vesting validator set-identity` command calls).
    - **browser owner** → the same `buildTx(VESTING_ABI, vesting, "vestingValidatorSetIdentity", [...])` calldata builder, sent through the shared wizard browser session (same mechanism as the vesting join). No `extraCid` in the wizard → sent empty (`0x`).
  - **Non-interactive**: `--moniker` + identity flags now set vesting identity too. No `--moniker` → skipped (same as the wallet path).
  - **`--skip-identity`** remains the opt-out; the wallet path is byte-for-byte unchanged.
  - **Error handling**: a revert (e.g. consensus gaps) is caught — the wizard warns via the existing error path and still reaches the summary, keeping the just-created validator info. Guard: if the created wallet address is unknown, it warns and points at the standalone command rather than sending a doomed tx.
  - "Set it later" hints are now funding-source-aware.

## SDK method used

`vestingValidatorSetIdentity` (from the genlayer-js vesting actions, per the `VestingClient` shim in `src/commands/vesting/vestingTypes.ts`). No SDK gap.

## Tests

`tests/actions/stakingWizard.test.ts` — 24 tests (was 18), all green; full suite 782 passed. New coverage:
- keystore vesting: guided identity → `vestingValidatorSetIdentity` with the created wallet + `extraCid: 0x`
- browser vesting: identity calldata built for `vestingValidatorSetIdentity` and sent through the same session (never keystore)
- non-interactive vesting: identity set from `--moniker`/flags; and skipped without `--moniker`
- vesting identity revert is caught → warns, no top-level failure, summary still runs
- `--skip-identity` respected on the vesting path (no prompt, no call)
- wallet path unchanged (existing tests intact)

Hermetic (mocked client/session/fs; no network / `~/.genlayer` / browser tabs). No version bump. Build clean. Pre-existing tsc baseline (32) unchanged — zero new errors.