### PR TITLE
fix: compile deploy scripts in an isolated temp directory

### DIFF
--- a/src/commands/contracts/deploy.ts
+++ b/src/commands/contracts/deploy.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import os from "os";
 import path from "path";
 import {BaseAction} from "../../lib/actions/BaseAction";
 import {pathToFileURL} from "url";
@@ -34,9 +35,14 @@ export class DeployAction extends BaseAction {
   }
 
   private async executeTsScript(filePath: string, rpcUrl?: string): Promise<void> {
-    const outFile = filePath.replace(/\.ts$/, ".compiled.js");
+    let tempDir: string | undefined;
     this.startSpinner(`Transpiling TypeScript file: ${filePath}`);
     try {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "genlayer-deploy-"));
+      const outFile = path.join(
+        tempDir,
+        path.basename(filePath).replace(/\.ts$/, ".compiled.js"),
+      );
       buildSync({
         entryPoints: [filePath],
         outfile: outFile,
@@ -50,7 +56,9 @@ export class DeployAction extends BaseAction {
     } catch (error) {
       this.failSpinner(`Error executing: ${filePath}`, error);
     } finally {
-      fs.unlinkSync(outFile);
+      if (tempDir) {
+        fs.rmSync(tempDir, {recursive: true, force: true});
+      }
     }
   }
 

--- a/tests/actions/deploy.test.ts
+++ b/tests/actions/deploy.test.ts
@@ -28,6 +28,8 @@ describe("DeployAction", () => {
     vi.clearAllMocks();
     // Setup mocks before creating the action (needed for constructor)
     vi.mocked(os.homedir).mockReturnValue("/mocked/home");
+    vi.mocked(os.tmpdir).mockReturnValue("/mocked/tmp");
+    vi.mocked(fs.mkdtempSync).mockReturnValue("/mocked/tmp/genlayer-deploy-abc");
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({activeAccount: "default"}));
 
@@ -427,7 +429,7 @@ describe("DeployAction", () => {
 
   test("executeTsScript transpiles and executes TypeScript", async () => {
     const filePath = "/mocked/script.ts";
-    const outFile = "/mocked/script.compiled.js";
+    const outFile = "/mocked/tmp/genlayer-deploy-abc/script.compiled.js";
 
     vi.spyOn(deployer as any, "executeJsScript").mockResolvedValue(undefined);
     vi.mocked(buildSync).mockImplementation((() => {}) as any);
@@ -446,7 +448,12 @@ describe("DeployAction", () => {
     });
 
     expect(deployer["executeJsScript"]).toHaveBeenCalledWith(filePath, outFile, undefined);
-    expect(fs.unlinkSync).toHaveBeenCalledWith(outFile);
+    expect(fs.mkdtempSync).toHaveBeenCalledWith("/mocked/tmp/genlayer-deploy-");
+    expect(fs.rmSync).toHaveBeenCalledWith("/mocked/tmp/genlayer-deploy-abc", {
+      recursive: true,
+      force: true,
+    });
+    expect(fs.unlinkSync).not.toHaveBeenCalled();
   });
 
   test("deployScripts fails when deploy folder is missing", async () => {
@@ -595,6 +602,10 @@ describe("DeployAction", () => {
     await deployer["executeTsScript"](filePath);
 
     expect(deployer["failSpinner"]).toHaveBeenCalledWith(`Error executing: ${filePath}`, error);
+    expect(fs.rmSync).toHaveBeenCalledWith("/mocked/tmp/genlayer-deploy-abc", {
+      recursive: true,
+      force: true,
+    });
   });
 
   test("deploys contract with rpc option", async () => {
@@ -649,7 +660,7 @@ describe("DeployAction", () => {
 
   test("executeTsScript passes rpc url to executeJsScript", async () => {
     const filePath = "/mocked/script.ts";
-    const outFile = "/mocked/script.compiled.js";
+    const outFile = "/mocked/tmp/genlayer-deploy-abc/script.compiled.js";
     const rpcUrl = "https://custom-rpc-url.com";
 
     vi.spyOn(deployer as any, "executeJsScript").mockResolvedValue(undefined);
@@ -669,7 +680,10 @@ describe("DeployAction", () => {
     });
 
     expect(deployer["executeJsScript"]).toHaveBeenCalledWith(filePath, outFile, rpcUrl);
-    expect(fs.unlinkSync).toHaveBeenCalledWith(outFile);
+    expect(fs.rmSync).toHaveBeenCalledWith("/mocked/tmp/genlayer-deploy-abc", {
+      recursive: true,
+      force: true,
+    });
   });
 
   test("deployScripts passes rpc url to script execution methods", async () => {

--- a/tests/actions/deploy.test.ts
+++ b/tests/actions/deploy.test.ts
@@ -1,6 +1,7 @@
 import {describe, test, vi, beforeEach, afterEach, expect} from "vitest";
 import fs from "fs";
 import os from "os";
+import path from "path";
 import {createClient, createAccount, isSuccessful, formatStakingAmount, DEPLOY_CALL_KEY} from "genlayer-js";
 import {DeployAction, DeployOptions} from "../../src/commands/contracts/deploy";
 import {buildSync} from "esbuild";
@@ -429,7 +430,7 @@ describe("DeployAction", () => {
 
   test("executeTsScript transpiles and executes TypeScript", async () => {
     const filePath = "/mocked/script.ts";
-    const outFile = "/mocked/tmp/genlayer-deploy-abc/script.compiled.js";
+    const outFile = path.join("/mocked/tmp/genlayer-deploy-abc", "script.compiled.js");
 
     vi.spyOn(deployer as any, "executeJsScript").mockResolvedValue(undefined);
     vi.mocked(buildSync).mockImplementation((() => {}) as any);
@@ -448,7 +449,7 @@ describe("DeployAction", () => {
     });
 
     expect(deployer["executeJsScript"]).toHaveBeenCalledWith(filePath, outFile, undefined);
-    expect(fs.mkdtempSync).toHaveBeenCalledWith("/mocked/tmp/genlayer-deploy-");
+    expect(fs.mkdtempSync).toHaveBeenCalledWith(path.join("/mocked/tmp", "genlayer-deploy-"));
     expect(fs.rmSync).toHaveBeenCalledWith("/mocked/tmp/genlayer-deploy-abc", {
       recursive: true,
       force: true,
@@ -660,7 +661,7 @@ describe("DeployAction", () => {
 
   test("executeTsScript passes rpc url to executeJsScript", async () => {
     const filePath = "/mocked/script.ts";
-    const outFile = "/mocked/tmp/genlayer-deploy-abc/script.compiled.js";
+    const outFile = path.join("/mocked/tmp/genlayer-deploy-abc", "script.compiled.js");
     const rpcUrl = "https://custom-rpc-url.com";
 
     vi.spyOn(deployer as any, "executeJsScript").mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- compile TypeScript deploy scripts outside the source tree
- clean the temporary directory safely after success or failure
- prevent existing sibling `.compiled.js` files from being overwritten or deleted

## Verification
- `npm test -- --run` (792 passed)
- `npm run build`