### PR TITLE
fix(security): restrict keystore file permissions to 0o600

### DIFF
--- a/src/commands/account/export.ts
+++ b/src/commands/account/export.ts
@@ -1,6 +1,6 @@
 import {BaseAction} from "../../lib/actions/BaseAction";
 import {ethers} from "ethers";
-import {writeFileSync, existsSync, readFileSync} from "fs";
+import {writeFileSync, existsSync, readFileSync, chmodSync} from "fs";
 import path from "path";
 
 export interface ExportAccountOptions {
@@ -60,7 +60,12 @@ export class ExportAccountAction extends BaseAction {
       const encryptedJson = await wallet.encrypt(password);
 
       // Write standard web3 keystore format (compatible with geth, foundry, etc.)
-      writeFileSync(outputPath, encryptedJson);
+      writeFileSync(outputPath, encryptedJson, { mode: 0o600 });
+      try {
+        chmodSync(outputPath, 0o600);
+      } catch {
+        // chmod can fail on Windows (no POSIX permissions)
+      }
 
       this.succeedSpinner(`Account '${accountName}' exported to: ${outputPath}`);
       this.logInfo(`Address: ${wallet.address}`);

--- a/src/commands/account/import.ts
+++ b/src/commands/account/import.ts
@@ -1,6 +1,6 @@
 import {BaseAction} from "../../lib/actions/BaseAction";
 import {ethers} from "ethers";
-import {writeFileSync, existsSync, readFileSync} from "fs";
+import {writeFileSync, existsSync, readFileSync, chmodSync} from "fs";
 
 export interface ImportAccountOptions {
   privateKey?: string;
@@ -62,7 +62,12 @@ export class ImportAccountAction extends BaseAction {
       const encryptedJson = await wallet.encrypt(password);
 
       // Write standard web3 keystore format directly
-      writeFileSync(keystorePath, encryptedJson);
+      writeFileSync(keystorePath, encryptedJson, { mode: 0o600 });
+      try {
+        chmodSync(keystorePath, 0o600);
+      } catch {
+        // chmod can fail on Windows (no POSIX permissions)
+      }
 
       if (options.setActive !== false) {
         this.setActiveAccount(options.name);

--- a/src/lib/actions/BaseAction.ts
+++ b/src/lib/actions/BaseAction.ts
@@ -59,7 +59,7 @@ export function resolveNetwork(stored: string | undefined, customNetworks?: Cust
   }
 }
 import { ethers } from "ethers";
-import { writeFileSync, existsSync, readFileSync } from "fs";
+import { writeFileSync, existsSync, readFileSync, chmodSync } from "fs";
 
 export class BaseAction extends ConfigFileManager {
   private static readonly DEFAULT_ACCOUNT_NAME = "default";
@@ -219,7 +219,16 @@ export class BaseAction extends ConfigFileManager {
 
     // Write standard web3 keystore format directly
     const encryptedJson = await wallet.encrypt(password);
-    writeFileSync(keystorePath, encryptedJson);
+    writeFileSync(keystorePath, encryptedJson, { mode: 0o600 });
+    // Enforce restrictive permissions even if the file already existed (writeFileSync
+    // does not change the mode of an existing file, so an attacker who pre-created it
+    // with 0644 would keep world-read access to the encrypted private key).
+    try {
+      chmodSync(keystorePath, 0o600);
+    } catch {
+      // chmod can fail on Windows (no POSIX permissions) — the encrypted keystore
+      // still protects the key, and Windows ACLs govern access there anyway.
+    }
 
     // Set as active account if no active account exists
     if (!this.getActiveAccount()) {


### PR DESCRIPTION
## Problem

Keystore files containing **encrypted private keys** are written via `writeFileSync` without specifying a file mode, leaving them with the default `0644` permissions — **world-readable** on POSIX systems. Any local user on the machine can read the encrypted keystore and attempt offline brute-force attacks on the password.

This affects three code paths:

1. `BaseAction.createKeypairByName()` (line 222) — account creation
2. `ExportAccountAction.execute()` (export.ts:55) — exporting an account to a keystore file
3. `ImportAccountAction.execute()` (import.ts:72) — importing an account into a keystore file

```typescript
// Before — world-readable (0644 on POSIX)
writeFileSync(keystorePath, encryptedJson);
```

## Fix

Pass `{ mode: 0o600 }` to `writeFileSync` **and** explicitly `chmodSync` to `0o600` afterwards:

```typescript
// After — owner-only read/write (0600 on POSIX)
writeFileSync(keystorePath, encryptedJson, { mode: 0o600 });
try {
  chmodSync(keystorePath, 0o600);
} catch {
  // chmod can fail on Windows (no POSIX permissions)
}
```

The explicit `chmodSync` is necessary because `writeFileSync` does **not** change the mode of an already-existing file — so a file pre-created by an attacker with `0644` would keep world-read access even with the `mode` option. The `chmod` is wrapped in `try/catch` because it is a no-op on Windows (no POSIX permissions; Windows ACLs govern access there).

This is the same pattern the `genswarms-telegram` curl client already uses (`File.chmod(config_path, 0o600)`) for sensitive temp files.

## Testing

- TypeScript type check passes on all three modified files (pre-existing errors in unrelated `stakingInfo.ts`/`StakingAction.ts` are not affected)
- No behavioral change to the happy path — only file permissions are restricted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Keystore files created, imported, or exported by the application now use restrictive file permissions to help prevent unauthorized access.
  * Permission enforcement is handled safely across platforms that do not support POSIX file permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->