### PR TITLE
fix(template): repair broken Discord badge in the default project template

### DIFF
--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -1,6 +1,6 @@
 # Sample GenLayer project
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/license/mit/)
-[![Discord](https://dcbadge.vercel.app/api/server/8Jm4v89VAu?compact=true&style=flat)](https://discord.gg/8Jm4v89VAu)
+[![Discord](https://dcbadge.limes.pink/api/server/8Jm4v89VAu?compact=true&style=flat)](https://discord.gg/8Jm4v89VAu)
 [![Telegram](https://img.shields.io/badge/Telegram--T.svg?style=social&logo=telegram)](https://t.me/genlayer)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/yeagerai.svg?style=social&label=Follow%20%40GenLayer)](https://x.com/GenLayer)
 [![GitHub star chart](https://img.shields.io/github/stars/yeagerai/genlayer-project-boilerplate?style=social)](https://star-history.com/#yeagerai/genlayer-js)


### PR DESCRIPTION
## Problem

The Discord badge points at **`dcbadge.vercel.app`**, which no longer serves badges — the request returns **HTTP 404**, so the badge renders as a broken image:

```
404  https://dcbadge.vercel.app/api/server/8Jm4v89VAu?compact=true&style=flat
```

The project moved to **`dcbadge.limes.pink`**, which keeps the exact same API path and query parameters:

```
200  https://dcbadge.limes.pink/api/server/8Jm4v89VAu?compact=true&style=flat
```

(The old host answers 404 to any user agent; the new host returns 200 — it does reject some non-browser agents with 403, which is why a naive checker can miss it.)

## Fix

Swap the host, nothing else — same path, same query string, so the badge renders exactly as before:

```diff
-[![Discord](https://dcbadge.vercel.app/api/server/8Jm4v89VAu?compact=true&style=flat)](...)
+[![Discord](https://dcbadge.limes.pink/api/server/8Jm4v89VAu?compact=true&style=flat)](...)
```

The Discord invite link itself is untouched.

## Why this one matters a bit more

This README lives in `templates/default/`, so it is scaffolded into **every new project created with the CLI**. Right now each generated project ships with a broken Discord badge in its README from the first commit.

## Note (not changed here)

The same template block also carries a star-chart badge pointing at `yeagerai/genlayer-project-boilerplate` / `star-history.com/#yeagerai/genlayer-js`, which is both the old org and a different repository. I left it alone since it's arguably a separate question for a scaffolded template (a generated project probably shouldn't advertise the boilerplate's stars at all) — happy to fix or drop it in a follow-up if you have a preference.

Docs-only, one line.