### PR TITLE
Fix: Prevent CI hang by explicitly running vitest once

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "genlayer": "./dist/index.js"
   },
   "scripts": {
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",
     "test:smoke": "vitest run --config vitest.smoke.config.ts",


### PR DESCRIPTION
This PR updates the test script in package.json to use vitest run.

Without the run flag, vitest defaults to watch mode, which blocks automated CI pipelines from completing. This change ensures the test suite runs once and terminates correctly in CI environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test command to run once and exit automatically, instead of staying in watch mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->