### PR TITLE
fix: prompt when network argument is empty

### DIFF
--- a/src/commands/network/setNetwork.ts
+++ b/src/commands/network/setNetwork.ts
@@ -98,7 +98,7 @@ export class NetworkActions extends BaseAction {
   async setNetwork(networkName?: string): Promise<void> {
     const entries = this.getNetworkEntries();
 
-    if (networkName || networkName === "") {
+    if (networkName) {
       const selectedNetwork = entries.find(n =>
         n.alias === networkName || (n.type === "built-in" && n.name === networkName),
       );

--- a/tests/actions/setNetwork.test.ts
+++ b/tests/actions/setNetwork.test.ts
@@ -85,12 +85,18 @@ describe("NetworkActions", () => {
     expect(networkActions["succeedSpinner"]).not.toHaveBeenCalled();
   });
 
-  test("setNetwork method fails for empty network name", async () => {
+  test("setNetwork method prompts user when an empty network name is provided", async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      selectedNetwork: "localnet",
+    });
+
     await networkActions.setNetwork("");
 
-    expect(networkActions["failSpinner"]).toHaveBeenCalledWith("Network  not found");
-    expect(networkActions["writeConfig"]).not.toHaveBeenCalled();
-    expect(networkActions["succeedSpinner"]).not.toHaveBeenCalled();
+    expect(inquirer.prompt).toHaveBeenCalled();
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith("network", "localnet");
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${localnet.name}`,
+    );
   });
 
   test("setNetwork method prompts user when no network name provided", async () => {


### PR DESCRIPTION
Closes #306

## Summary

Treat an empty network argument as omitted so `genlayer network set ""` opens the interactive network selector instead of attempting to resolve an empty alias.

## Changes

- Simplified the explicit-network condition to require a non-empty value.
- - Updated the focused test to verify prompting, configuration, and success output for an empty argument.
## Validation

`git diff --check` passed. Local Vitest and TypeScript binaries were unavailable in the sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network selection when no network is specified.
  - Users are now prompted to choose a network instead of receiving an error for an empty selection.
  - Interactive configuration can successfully proceed with the selected local network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->