### PR TITLE
style: move BaseAction imports to top

### DIFF
--- a/src/lib/actions/BaseAction.ts
+++ b/src/lib/actions/BaseAction.ts
@@ -1,5 +1,7 @@
 import {ConfigFileManager} from "../../lib/config/ConfigFileManager";
 import {KeychainManager} from "../../lib/config/KeychainManager";
+import { ethers } from "ethers";
+import { writeFileSync, existsSync, readFileSync } from "fs";
 import ora, {Ora} from "ora";
 import chalk from "chalk";
 import inquirer from "inquirer";
@@ -58,8 +60,6 @@ export function resolveNetwork(stored: string | undefined, customNetworks?: Cust
     throw new Error(`Unknown network: ${stored}`);
   }
 }
-import { ethers } from "ethers";
-import { writeFileSync, existsSync, readFileSync } from "fs";
 
 export class BaseAction extends ConfigFileManager {
   private static readonly DEFAULT_ACCOUNT_NAME = "default";


### PR DESCRIPTION
Closes #307

Move the ethers and filesystem imports in `BaseAction.ts` into the top-level import block. This removes imports from the middle of the module, aligns the file with TypeScript and ESLint conventions, and avoids confusing static import analysis.

Validation: `git diff --check` passed. Full local TypeScript and test validation was unavailable because dependencies are not installed in the sandbox.