### PR TITLE
fix: harden config and keystore handling

### DIFF
--- a/src/commands/config/getSetReset.ts
+++ b/src/commands/config/getSetReset.ts
@@ -44,8 +44,7 @@ export class ConfigActions extends BaseAction {
       return;
     }
 
-    delete config[key];
-    this.writeConfig(key, undefined);
+    this.removeConfig(key);
     this.succeedSpinner(`Configuration successfully reset`);
   }
 }

--- a/src/lib/actions/BaseAction.ts
+++ b/src/lib/actions/BaseAction.ts
@@ -91,8 +91,14 @@ export class BaseAction extends ConfigFileManager {
 
       return wallet.privateKey;
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isPasswordError = /password|decrypt/i.test(message);
+      if (!isPasswordError) {
+        throw error;
+      }
       if (attempt >= BaseAction.MAX_PASSWORD_ATTEMPTS) {
         this.failSpinner(`Maximum password attempts exceeded (${BaseAction.MAX_PASSWORD_ATTEMPTS}/${BaseAction.MAX_PASSWORD_ATTEMPTS}).`);
+        throw new Error("Maximum password attempts exceeded");
       }
       return await this.decryptKeystore(keystoreJson, attempt + 1);
     }
@@ -149,6 +155,10 @@ export class BaseAction extends ConfigFileManager {
     if (!existsSync(keystorePath)) {
       await this.confirmPrompt(`Account '${accountName}' not found. Would you like to create it?`);
       decryptedPrivateKey = await this.createKeypairByName(accountName, false);
+      if (!existsSync(keystorePath)) {
+        this.failSpinner(`Failed to create keystore file for account '${accountName}'.`, undefined, false);
+        throw new Error(`Failed to create keystore file for account '${accountName}'.`);
+      }
     }
 
     keystoreJson = readFileSync(keystorePath, "utf-8");


### PR DESCRIPTION
Closes #305
Closes #304
Closes #302 

## Summary

- Remove configuration keys correctly during `config reset` instead of writing an undefined value into the JSON file.
- - Detect a failed keystore creation before attempting to read the missing file and report a clear error.
- - Re-raise malformed or corrupted keystore errors instead of treating every failure as an incorrect password, and stop retry recursion after the configured maximum.
## Validation

`git diff --check` passed. TypeScript dependencies were unavailable locally, so the repository typecheck could not run in the sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting configuration now properly removes settings instead of saving undefined values.
  * Improved keystore error handling by retrying only password-related failures.
  * Added verification that a keystore is created successfully after account creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->