### PR TITLE
fix: prompt when network argument is empty

### DIFF
--- a/src/commands/network/setNetwork.ts
+++ b/src/commands/network/setNetwork.ts
@@ -98,7 +98,7 @@ export class NetworkActions extends BaseAction {
   async setNetwork(networkName?: string): Promise<void> {
     const entries = this.getNetworkEntries();
 
-    if (networkName || networkName === "") {
+    if (networkName) {
       const selectedNetwork = entries.find(n =>
         n.alias === networkName || (n.type === "built-in" && n.name === networkName),
       );

--- a/tests/actions/setNetwork.test.ts
+++ b/tests/actions/setNetwork.test.ts
@@ -85,12 +85,19 @@ describe("NetworkActions", () => {
     expect(networkActions["succeedSpinner"]).not.toHaveBeenCalled();
   });
 
-  test("setNetwork method fails for empty network name", async () => {
+  test("setNetwork method prompts user for an empty network name", async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      selectedNetwork: "localnet",
+    });
+
     await networkActions.setNetwork("");
 
-    expect(networkActions["failSpinner"]).toHaveBeenCalledWith("Network  not found");
-    expect(networkActions["writeConfig"]).not.toHaveBeenCalled();
-    expect(networkActions["succeedSpinner"]).not.toHaveBeenCalled();
+    expect(inquirer.prompt).toHaveBeenCalled();
+    expect(networkActions["writeConfig"]).toHaveBeenCalledWith("network", "localnet");
+    expect(networkActions["succeedSpinner"]).toHaveBeenCalledWith(
+      `Network successfully set to ${localnet.name}`,
+    );
+    expect(networkActions["failSpinner"]).not.toHaveBeenCalled();
   });
 
   test("setNetwork method prompts user when no network name provided", async () => {


### PR DESCRIPTION
### Summary

Closes #306.

An empty string passed to `genlayer network set ""` now follows the interactive network selector path. The CLI no longer emits a malformed `Network  not found` error for an empty argument.

### How did you test your changes?

- `git diff --check`
- - Updated the focused setNetwork test to cover empty-string input.
- - Local formatting and Vitest execution were unavailable because dependencies were not installed in the sandbox.