### PR TITLE
fix(config): keep '=' inside the value of config set

### DIFF
--- a/src/commands/config/getSetReset.ts
+++ b/src/commands/config/getSetReset.ts
@@ -7,7 +7,12 @@ export class ConfigActions extends BaseAction {
   }
 
   set(keyValue: string): void {
-    const [key, value] = keyValue.split("=");
+    // Split on the first "=" only. Config values legitimately contain "=" —
+    // base64 padding, URLs with a query string — and splitting on every one
+    // silently stored a truncated value.
+    const separatorIndex = keyValue.indexOf("=");
+    const key = separatorIndex === -1 ? "" : keyValue.slice(0, separatorIndex);
+    const value = separatorIndex === -1 ? undefined : keyValue.slice(separatorIndex + 1);
     this.startSpinner(`Updating configuration: ${key}`);
 
     if (!key || value === undefined) {

--- a/tests/actions/getSetReset.test.ts
+++ b/tests/actions/getSetReset.test.ts
@@ -28,6 +28,27 @@ describe("ConfigActions", () => {
     expect(configActions["succeedSpinner"]).toHaveBeenCalledWith("Configuration successfully updated");
   });
 
+  test("set method keeps '=' inside the value", () => {
+    configActions.set("apiKey=YWJjZGVm==");
+
+    expect(configActions["writeConfig"]).toHaveBeenCalledWith("apiKey", "YWJjZGVm==");
+  });
+
+  test("set method keeps a query string intact", () => {
+    configActions.set("rpcUrl=https://rpc.example.com/v1?key=abc&mode=fast");
+
+    expect(configActions["writeConfig"]).toHaveBeenCalledWith(
+      "rpcUrl",
+      "https://rpc.example.com/v1?key=abc&mode=fast",
+    );
+  });
+
+  test("set method accepts an empty value", () => {
+    configActions.set("defaultNetwork=");
+
+    expect(configActions["writeConfig"]).toHaveBeenCalledWith("defaultNetwork", "");
+  });
+
   test("set method fails for invalid format", () => {
     configActions.set("invalidFormat");
 


### PR DESCRIPTION
## Problem

`config set` destructures the split, so it only ever keeps the first two parts:

```ts
const [key, value] = keyValue.split("=");
```

A value containing `=` is silently truncated at the first one. Two everyday cases:

```
genlayer config set apiKey=YWJjZGVm==
  stored: YWJjZGVm                          # base64 padding dropped

genlayer config set rpcUrl=https://rpc.example.com/v1?key=abc&mode=fast
  stored: https://rpc.example.com/v1?key    # query string cut off
```

There is no error and no warning. The command reports `Configuration successfully updated`, and the value only turns out to be wrong later, when whatever reads it fails for a reason that does not point back here.

## Change

Splits on the first separator instead:

```ts
const separatorIndex = keyValue.indexOf("=");
const key = separatorIndex === -1 ? "" : keyValue.slice(0, separatorIndex);
const value = separatorIndex === -1 ? undefined : keyValue.slice(separatorIndex + 1);
```

The two existing behaviours are unchanged:

- no separator at all (`config set invalidFormat`) still fails with `Invalid format. Use 'key=value'.`
- an empty value (`config set defaultNetwork=`) still stores `""`

## Tests

Three cases added to `tests/actions/getSetReset.test.ts`: base64 padding, a query string, and the empty value. The first two fail on `v0.40-dev` and pass with the change; the empty-value and invalid-format tests pass either way, which is what pins the unchanged behaviour.

## Verification

Run against `v0.40-dev` at `e822a9e`:

```
npx vitest run                          72 files, 799 tests, all passing
npx vitest run tests/actions/getSetReset.test.ts   10 passing
```

And with the fix reverted, to confirm the new tests actually catch it:

```
× set method keeps '=' inside the value
  → expected "writeConfig" to be called with arguments: [ 'apiKey', 'YWJjZGVm==' ]
× set method keeps a query string intact
  → expected "writeConfig" to be called with arguments: [ 'rpcUrl', …(1) ]
```

## Branch

Targeting `v0.40-dev` as the active integration branch per `docs/BRANCHING.md`. Happy to retarget at a stable branch if you would rather ship it directly.

## One thing I left alone

`reset()` has a `delete config[key]` that operates on a local copy and is never written back — the removal actually happens because `writeConfig(key, undefined)` makes `JSON.stringify` drop the key. It works, so I did not touch it here, but `removeConfig(key)` already exists and says it directly. Happy to send that separately if it is worth having.
