### PR TITLE
feat: add --gas to contract deploy and write

### DIFF
--- a/docs/api-references/contracts/deploy.mdx
+++ b/docs/api-references/contracts/deploy.mdx
@@ -20,6 +20,7 @@ Deploy intelligent contracts
 |  | --appeal-rounds &lt;count&gt; | Override fee profile appeal rounds | No |  |
 |  | --fee-value &lt;wei&gt; | Fee deposit value to send with the transaction | No |  |
 |  | --valid-until &lt;unixTimestamp&gt; | Unix timestamp after which the transaction is invalid | No |  |
+|  | --gas &lt;units&gt; | Outer EVM transaction gas limit; separate from GenLayer fee budgets | No |  |
 |  | --args &lt;args...&gt; | Contract arguments. Supported types: | No |  |
 |  | --wallet &lt;mode&gt; | Signing mode: 'keystore' or 'browser' (sign in MetaMask via a local bridge; forward the port for remote/SSH: ssh -L &lt;port&gt;:127.0.0.1:&lt;port&gt;). Defaults to the 'walletMode' config value, else 'keystore'. | No |  |
 | -h | --help | display help for command | No |  |

--- a/docs/api-references/contracts/write.mdx
+++ b/docs/api-references/contracts/write.mdx
@@ -24,6 +24,7 @@ Sends a transaction to a contract method that modifies the state
 |  | --appeal-rounds &lt;count&gt; | Override fee profile appeal rounds | No |  |
 |  | --fee-value &lt;wei&gt; | Fee deposit value to send with the transaction | No |  |
 |  | --valid-until &lt;unixTimestamp&gt; | Unix timestamp after which the transaction is invalid | No |  |
+|  | --gas &lt;units&gt; | Outer EVM transaction gas limit; separate from GenLayer fee budgets | No |  |
 |  | --args &lt;args...&gt; | Contract arguments. Supported types: | No |  |
 |  | --wallet &lt;mode&gt; | Signing mode: 'keystore' or 'browser' (sign in MetaMask via a local bridge; forward the port for remote/SSH: ssh -L &lt;port&gt;:127.0.0.1:&lt;port&gt;). Defaults to the 'walletMode' config value, else 'keystore'. | No |  |
 | -h | --help | display help for command | No |  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "eslint-config-prettier": "^10.0.0",
         "eslint-import-resolver-typescript": "^4.0.0",
         "eslint-plugin-import": "^2.29.1",
-        "genlayer-js": "github:genlayerlabs/genlayer-js#6f1273885567ff5cda77b7459edfd6666c5859d0",
+        "genlayer-js": "github:genlayerlabs/genlayer-js#869ef09a0a54c2f47a5ecf59a6caa6c2d0db6208",
         "jsdom": "^26.0.0",
         "prettier": "^3.2.5",
         "release-it": "^19.0.0",
@@ -5683,8 +5683,8 @@
     },
     "node_modules/genlayer-js": {
       "version": "1.1.8",
-      "resolved": "git+ssh://git@github.com/genlayerlabs/genlayer-js.git#6f1273885567ff5cda77b7459edfd6666c5859d0",
-      "integrity": "sha512-ts4KjgqO/qR8pKiCOp+g5FKbAKUyLLIFTuXX6+ZjFYKOhTHPP3kL+CR4siVKp4YGVWWk+/DWeVXgCMZOBo1QLA==",
+      "resolved": "git+ssh://git@github.com/genlayerlabs/genlayer-js.git#869ef09a0a54c2f47a5ecf59a6caa6c2d0db6208",
+      "integrity": "sha512-OAwtbuPO+81wOmHim7bI5YBaEBEzAU3rN0PZu8PHO8dC25l3dwLkiMZnPmL9D1AH4JKPVyN12PmJ6m65XWry1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-config-prettier": "^10.0.0",
     "eslint-import-resolver-typescript": "^4.0.0",
     "eslint-plugin-import": "^2.29.1",
-    "genlayer-js": "github:genlayerlabs/genlayer-js#6f1273885567ff5cda77b7459edfd6666c5859d0",
+    "genlayer-js": "github:genlayerlabs/genlayer-js#869ef09a0a54c2f47a5ecf59a6caa6c2d0db6208",
     "jsdom": "^26.0.0",
     "prettier": "^3.2.5",
     "release-it": "^19.0.0",

--- a/src/commands/contracts/deploy.ts
+++ b/src/commands/contracts/deploy.ts
@@ -6,9 +6,10 @@ import {pathToFileURL} from "url";
 import {formatStakingAmount} from "genlayer-js";
 import {buildSync} from "esbuild";
 import {ContractFeeCliOptions, parseValidUntil, resolveTransactionFees} from "./fees";
+import {ContractTransactionCliOptions, parseGas} from "./transaction";
 import {assertSuccessfulExecution, transactionConsensusStatus} from "./execution";
 
-export interface DeployOptions extends ContractFeeCliOptions {
+export interface DeployOptions extends ContractFeeCliOptions, ContractTransactionCliOptions {
   contract?: string;
   args?: any[];
   rpc?: string;
@@ -153,6 +154,7 @@ export class DeployAction extends BaseAction {
 
       const leaderOnly = false;
       const deployParams: any = {code: contractCode, args: options.args, leaderOnly};
+      const gas = parseGas(options.gas);
       const fees = await resolveTransactionFees(client, options, {
         deployTargeted: true,
         profileTarget: {kind: "deploy"},
@@ -160,6 +162,7 @@ export class DeployAction extends BaseAction {
       const validUntil = parseValidUntil(options);
       if (fees) deployParams.fees = fees;
       if (validUntil !== undefined) deployParams.validUntil = validUntil;
+      if (gas !== undefined) deployParams.gas = gas;
 
       this.setSpinnerText("Starting contract deployment...");
       if (fees?.feeValue !== undefined) {

--- a/src/commands/contracts/index.ts
+++ b/src/commands/contracts/index.ts
@@ -120,6 +120,10 @@ export function initializeContractsCommands(program: Command) {
       .option("--appeal-rounds <count>", "Override fee profile appeal rounds")
       .option("--fee-value <wei>", "Fee deposit value to send with the transaction")
       .option("--valid-until <unixTimestamp>", "Unix timestamp after which the transaction is invalid")
+      .option(
+        "--gas <units>",
+        "Outer EVM transaction gas limit; separate from GenLayer fee budgets",
+      )
       .option("--args <args...>", ARGS_HELP, parseArg, []),
   ).action(async (options: DeployOptions) => {
       const deployer = new DeployAction();
@@ -152,6 +156,10 @@ export function initializeContractsCommands(program: Command) {
       .option("--appeal-rounds <count>", "Override fee profile appeal rounds")
       .option("--fee-value <wei>", "Fee deposit value to send with the transaction")
       .option("--valid-until <unixTimestamp>", "Unix timestamp after which the transaction is invalid")
+      .option(
+        "--gas <units>",
+        "Outer EVM transaction gas limit; separate from GenLayer fee budgets",
+      )
       .option("--args <args...>", ARGS_HELP, parseArg, []),
   ).action(async (contractAddress: string, method: string, options: WriteOptions) => {
       const writeAction = new WriteAction();

--- a/src/commands/contracts/transaction.ts
+++ b/src/commands/contracts/transaction.ts
@@ -1,0 +1,19 @@
+export interface ContractTransactionCliOptions {
+  /** Gas limit for the outer EVM transaction submitted to ConsensusMain. */
+  gas?: string;
+}
+
+export const parseGas = (value: string | undefined): bigint | undefined => {
+  if (value === undefined) return undefined;
+
+  const trimmed = value.trim();
+  if (!/^(0x[0-9a-fA-F]+|[0-9]+)$/.test(trimmed)) {
+    throw new Error("--gas must be a positive integer.");
+  }
+
+  const gas = BigInt(trimmed);
+  if (gas <= 0n) {
+    throw new Error("--gas must be a positive integer.");
+  }
+  return gas;
+};

--- a/src/commands/contracts/write.ts
+++ b/src/commands/contracts/write.ts
@@ -3,9 +3,10 @@
 import {formatStakingAmount} from "genlayer-js";
 import {BaseAction} from "../../lib/actions/BaseAction";
 import {ContractFeeCliOptions, parseValidUntil, resolveTransactionFees} from "./fees";
+import {ContractTransactionCliOptions, parseGas} from "./transaction";
 import {assertSuccessfulExecution, transactionConsensusStatus} from "./execution";
 
-export interface WriteOptions extends ContractFeeCliOptions {
+export interface WriteOptions extends ContractFeeCliOptions, ContractTransactionCliOptions {
   args: any[];
   rpc?: string;
   wallet?: "keystore" | "browser";
@@ -28,6 +29,7 @@ export class WriteAction extends BaseAction {
     appealRounds,
     feeValue,
     validUntil,
+    gas,
   }: WriteOptions & {
     contractAddress: string;
     method: string;
@@ -45,6 +47,7 @@ export class WriteAction extends BaseAction {
         args,
         value: 0n,
       };
+      const parsedGas = parseGas(gas);
       const parsedFees = await resolveTransactionFees(
         client,
         {fees, feeProfile, feePreset, appealRounds, feeValue, validUntil},
@@ -60,6 +63,7 @@ export class WriteAction extends BaseAction {
       });
       if (parsedFees) writeParams.fees = parsedFees;
       if (parsedValidUntil !== undefined) writeParams.validUntil = parsedValidUntil;
+      if (parsedGas !== undefined) writeParams.gas = parsedGas;
       if (parsedFees?.feeValue !== undefined) {
         const parsedFeeValue = BigInt(parsedFees.feeValue);
         this.log(`Fee deposit: ${parsedFeeValue.toString()} wei (~${formatStakingAmount(parsedFeeValue)})`);

--- a/tests/actions/deploy.test.ts
+++ b/tests/actions/deploy.test.ts
@@ -119,6 +119,28 @@ describe("DeployAction", () => {
     expect(mockClient.deployContract).toHaveReturnedWith(Promise.resolve("mocked_tx_hash"));
   });
 
+  test("passes an explicit outer EVM gas limit to deployContract", async () => {
+    vi.mocked(fs.readFileSync).mockReturnValue("contract code");
+    vi.mocked(mockClient.deployContract).mockResolvedValue("mocked_tx_hash");
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue({
+      statusName: "ACCEPTED",
+      txExecutionResultName: "FINISHED_WITH_RETURN",
+      data: {contract_address: "0xdasdsadasdasdada"},
+    });
+
+    await deployer.deploy({
+      contract: "/mocked/contract/path",
+      gas: "31000000",
+    });
+
+    expect(mockClient.deployContract).toHaveBeenCalledWith({
+      code: "contract code",
+      args: undefined,
+      leaderOnly: false,
+      gas: 31_000_000n,
+    });
+  });
+
   test("deploys contract with fee options", async () => {
     const options: DeployOptions = {
       contract: "/mocked/contract/path",

--- a/tests/actions/transaction.test.ts
+++ b/tests/actions/transaction.test.ts
@@ -1,0 +1,23 @@
+import {describe, expect, test} from "vitest";
+import {parseGas} from "../../src/commands/contracts/transaction";
+
+describe("parseGas", () => {
+  test.each([
+    ["32000000", 32_000_000n],
+    [" 42 ", 42n],
+    ["0x5208", 21_000n],
+  ])("parses %s", (value, expected) => {
+    expect(parseGas(value)).toBe(expected);
+  });
+
+  test("omits gas when the option is absent", () => {
+    expect(parseGas(undefined)).toBeUndefined();
+  });
+
+  test.each(["0", "0x0", "-1", "1.5", "32_000_000", "nope"])(
+    "rejects invalid gas %s",
+    value => {
+      expect(() => parseGas(value)).toThrow("--gas must be a positive integer");
+    },
+  );
+});

--- a/tests/actions/write.test.ts
+++ b/tests/actions/write.test.ts
@@ -103,6 +103,28 @@ describe("WriteAction", () => {
     });
   });
 
+  test("passes an explicit outer EVM gas limit to writeContract", async () => {
+    const mockHash = "0xMockedTransactionHash";
+    const mockReceipt = {statusName: "ACCEPTED", txExecutionResultName: "FINISHED_WITH_RETURN"};
+    vi.mocked(mockClient.writeContract).mockResolvedValue(mockHash);
+    vi.mocked(mockClient.waitForTransactionReceipt).mockResolvedValue(mockReceipt);
+
+    await writeAction.write({
+      contractAddress: "0xMockedContract",
+      method: "updateData",
+      args: [],
+      gas: "32000000",
+    });
+
+    expect(mockClient.writeContract).toHaveBeenCalledWith({
+      address: "0xMockedContract",
+      functionName: "updateData",
+      args: [],
+      value: 0n,
+      gas: 32_000_000n,
+    });
+  });
+
   test("calls writeContract with fee options", async () => {
     const mockHash = "0xMockedTransactionHash";
     const mockReceipt = {statusName: "ACCEPTED", txExecutionResultName: "FINISHED_WITH_RETURN"};

--- a/tests/commands/deploy.test.ts
+++ b/tests/commands/deploy.test.ts
@@ -66,6 +66,8 @@ describe("deploy command", () => {
       "4",
       "--valid-until",
       "999",
+      "--gas",
+      "32000000",
     ]);
 
     expect(DeployAction.prototype.deploy).toHaveBeenCalledWith({
@@ -74,6 +76,7 @@ describe("deploy command", () => {
       fees,
       feeValue: "4",
       validUntil: "999",
+      gas: "32000000",
     });
   });
 

--- a/tests/commands/write.test.ts
+++ b/tests/commands/write.test.ts
@@ -68,6 +68,8 @@ describe("write command", () => {
       "4",
       "--valid-until",
       "999",
+      "--gas",
+      "32000000",
     ]);
 
     expect(WriteAction.prototype.write).toHaveBeenCalledWith({
@@ -77,6 +79,7 @@ describe("write command", () => {
       fees,
       feeValue: "4",
       validUntil: "999",
+      gas: "32000000",
     });
   });
 


### PR DESCRIPTION
## Delivery context

Depends-On: genlayerlabs/genlayer-js#215

## Problem and outcome

Contract deploy/write commands expose GenLayer fee controls but previously offered no way to set the outer EVM transaction gas limit. Large deployment calldata could therefore hit the SDK's old 200,000 fallback and fail with `intrinsic gas too low` before GenLayer accepted the transaction.

This PR:

- adds `--gas <units>` to `genlayer deploy` and `genlayer write`;
- accepts positive decimal or hexadecimal integer quantities;
- forwards the parsed `bigint` as the SDK's top-level `gas` option;
- describes it explicitly as the outer EVM limit, separate from GenLayer fee budgets;
- pins genlayer-js commit `869ef09a0a54c2f47a5ecf59a6caa6c2d0db6208`, the exact implementation in dependency PR #215;
- updates generated deploy/write command references.

This is an organization-owned replacement for #404 and credits @ygd58 for the original CLI gas-option proposal and test approach.

## Implementation and validation

- `npm test -- --run` — 808 tests passed against the pinned genlayer-js commit.
- `npm run build` — passed.
- `npm run docs:cli` — generated and verified the deploy/write references.
- Added parser coverage for decimal, hex, absent, zero, negative, fractional, underscore, and non-numeric values.
- Added action and command wiring coverage for both deploy and write.

The full wallet-session suite was run at host level because those tests bind to loopback; its initial sandbox-only failures were all `listen EPERM 127.0.0.1` and passed unchanged at host level.

## Decisions, risks, and rollback

- `--gas` remains a sibling of `--fees`, not a field inside it: the former controls the outer EVM envelope while the latter controls GenLayer budgets.
- The CLI does not invent a fallback or recommend a network-wide magic number; omission delegates to SDK estimation/headroom.
- The dependency is pinned to the exact reviewed JS commit, so the CLI cannot silently ship this flag against an older runtime.
- Reverting this commit removes the flag and restores the previous dependency pin.