### PR TITLE
fix(release): keep tag publish workflows active

### DIFF
--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -20,7 +20,9 @@
 
 module.exports = {
   git: {
-    commitMessage: "Release v${version} [skip ci]",
+    // Keep release commits CI-active: GitHub also suppresses tag-triggered
+    // workflows when the tagged commit contains a skip directive.
+    commitMessage: "Release v${version}",
     tagName: "v${version}",
     requireCleanWorkingDir: false,
     requireUpstream: false,

--- a/tests/release-channel.test.mjs
+++ b/tests/release-channel.test.mjs
@@ -1,5 +1,9 @@
+import {createRequire} from "node:module";
 import {describe, expect, it} from "vitest";
 import {resolveReleaseChannel} from "../scripts/resolve-release-channel.mjs";
+
+const require = createRequire(import.meta.url);
+const releaseConfig = require("../.release-it.cjs");
 
 describe("release channel policy", () => {
   it("publishes stable releases to latest", () => {
@@ -32,5 +36,13 @@ describe("release channel policy", () => {
     expect(() => resolveReleaseChannel("0.40.0-2.1", "0.40.0-2.1")).toThrow(
       "Invalid prerelease npm dist-tag",
     );
+  });
+
+  it("keeps release commits eligible for tag-triggered publishing", () => {
+    expect(releaseConfig.git.commitMessage).toBe("Release v${version}");
+    expect(releaseConfig.git.commitMessage).not.toMatch(
+      /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/i,
+    );
+    expect(releaseConfig.git.commitMessage).not.toMatch(/skip-checks:\s*true/i);
   });
 });


### PR DESCRIPTION
## Problem and outcome

The v0.40.0-rc.3 release script created `Release v0.40.0-rc.3 [skip ci]`. GitHub applied that directive to the tag push as well, so the tag-driven publish workflow never started and required an exact-tag manual dispatch.

This keeps release commits CI-active so future tag pushes start the repository-owned publish workflow automatically.

## Implementation

- Remove `[skip ci]` from the actual release-it commit template.
- Add a fast regression test that loads the real release config, requires the expected active commit template, and rejects every GitHub-recognized skip directive plus `skip-checks: true`.

## Validation

- Focused release policy: 6/6
- Full native suite: 76 files / 826 tests
- `git diff --check`

No full E2E is required: this changes release automation metadata and its direct unit test only.